### PR TITLE
Bugfix when passing empty bytes to detector

### DIFF
--- a/charset_normalizer/normalizer.py
+++ b/charset_normalizer/normalizer.py
@@ -348,6 +348,14 @@ class CharsetNormalizerMatches:
         if not explain:
             logger.disable('charset_normalizer')
 
+        if len(sequences) == 0:
+            return CharsetNormalizerMatch(
+                sequences,
+                'utf-8',
+                0.,
+                []
+            )
+
         too_small_sequence = len(sequences) < 24
 
         if too_small_sequence is True:

--- a/charset_normalizer/version.py
+++ b/charset_normalizer/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 VERSION = __version__.split('.')

--- a/test/test_on_byte.py
+++ b/test/test_on_byte.py
@@ -10,6 +10,18 @@ class TestBytes(unittest.TestCase):
             CnM.from_bytes(b'\xfe\xff').best().first()
         )
 
+    def test_empty_bytes(self):
+        r = CnM.from_bytes(b'').best().first()
+
+        self.assertIsNotNone(
+            r
+        )
+
+        self.assertEqual(
+            'utf-8',
+            r.encoding
+        )
+
     def test_bom_detection(self):
         with self.subTest('GB18030 UNAVAILABLE SIG'):
             self.assertFalse(


### PR DESCRIPTION
Return by default utf-8