### PR TITLE
:wrench: allow prettytable 2.0 even if they dropped py 3.5

### DIFF
--- a/charset_normalizer/version.py
+++ b/charset_normalizer/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 VERSION = __version__.split('.')

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ VERSION = get_version()
 REQUIRED = [
     'cached_property>=1.5,<2.0',
     'dragonmapper>=0.2,<0.3',
-    'prettytable>=1.0,<2.0',
+    'prettytable>=1.0,<3.0',
     'loguru>=0.5,<0.6'
 ]
 


### PR DESCRIPTION
Close #35 