### PR TITLE
:bug: Fix empty payload detection/alphabets listing

### DIFF
--- a/charset_normalizer/normalizer.py
+++ b/charset_normalizer/normalizer.py
@@ -353,7 +353,7 @@ class CharsetNormalizerMatches:
                 sequences,
                 'utf-8',
                 0.,
-                []
+                {}
             )
 
         too_small_sequence = len(sequences) < 24

--- a/test/test_on_byte.py
+++ b/test/test_on_byte.py
@@ -22,6 +22,11 @@ class TestBytes(unittest.TestCase):
             r.encoding
         )
 
+        self.assertEqual(
+            0,
+            len(r.alphabets)
+        )
+
     def test_bom_detection(self):
         with self.subTest('GB18030 UNAVAILABLE SIG'):
             self.assertFalse(


### PR DESCRIPTION
Related bug discovered by @potiuk see https://github.com/psf/requests/pull/5797#issuecomment-840044183
The exception happens when the payload is empty AND trying to use/uncovers alphabets.

Test added.