### PR TITLE
:heavy_check_mark: GHA tests was not using codecov action publish

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,3 +31,4 @@ jobs:
     - name: Run tests
       run: |
         pytest
+    - uses: codecov/codecov-action@v1


### PR DESCRIPTION
The migration from travis-ci to GHA was incomplete. 