### PR TITLE
Fix undesired exception (ValueError) on getitem of instance CharsetMatches

### DIFF
--- a/charset_normalizer/models.py
+++ b/charset_normalizer/models.py
@@ -264,11 +264,12 @@ class CharsetMatches:
     def __getitem__(self, item) -> CharsetMatch:
         """
         Retrieve a single item either by its position or encoding name (alias may be used here).
+        Raise KeyError upon invalid index or encoding not present in results.
         """
         if isinstance(item, int):
             return self._results[item]
         if isinstance(item, str):
-            item = iana_name(item)
+            item = iana_name(item, False)
             for result in self._results:
                 if item in result.could_be_from_charset:
                     return result


### PR DESCRIPTION
One could raise an unwanted exception upon a CharsetMatches instance.

```python
from charset_normalizer.api import from_path

if __name__ == "__main__":

    r = from_path("./data/sample.1.ar.srt")

    r["MacCyrilliX"]
```

In the current conditions, this would raise `ValueError` instead of `KeyError`.
