### PR TITLE
v2.0.1

### DIFF
--- a/charset_normalizer/version.py
+++ b/charset_normalizer/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 VERSION = __version__.split('.')


### PR DESCRIPTION
*Changes:*

  - **Bugfix:** :bug: Make it work where there isn't a filesystem available #54 #55 
  - **Improvement:** :sparkles: You may now use aliases in `cp_isolation` and `cp_exclusion` arguments #47 
  - **Bugfix:** :bug: Using explain=False permanently disable the verbose output in the current runtime #47 
  - **Bugfix:** :bug: One log entry (language target preemptive) was not show in logs when using `explain=True` #47 
  - **Bugfix:** :bug: Fix undesired exception (ValueError) on getitem of instance CharsetMatches #52 
  - **Improvement:** :wrench: Public function `normalize` default args values were not aligned with `from_bytes`  #53 

