### PR TITLE
Don't inject unicodedata2 into sys.modules

### DIFF
--- a/charset_normalizer/__init__.py
+++ b/charset_normalizer/__init__.py
@@ -25,9 +25,6 @@ from charset_normalizer.legacy import detect
 from charset_normalizer.version import __version__, VERSION
 from charset_normalizer.models import CharsetMatch, CharsetMatches
 
-# Load backport unicodedata2 if available
-import charset_normalizer.hook
-
 # Backward-compatible v1 imports
 from charset_normalizer.models import CharsetNormalizerMatch
 import charset_normalizer.api as CharsetDetector

--- a/charset_normalizer/hook.py
+++ b/charset_normalizer/hook.py
@@ -1,7 +1,0 @@
-import sys
-
-try:
-    import unicodedata2  # type: ignore
-    sys.modules['unicodedata'] = unicodedata2
-except ImportError:
-    pass

--- a/charset_normalizer/utils.py
+++ b/charset_normalizer/utils.py
@@ -1,4 +1,8 @@
-import unicodedata
+try:
+    import unicodedata2 as unicodedata
+except ImportError:
+    import unicodedata
+
 from codecs import IncrementalDecoder
 from re import findall
 from typing import Optional, Tuple, Union, List, Set


### PR DESCRIPTION
I noticed charset_normalizer meddles with `sys.modules`, causing this:

```
>>> import charset_normalizer
>>> import unicodedata
>>> unicodedata
<module 'unicodedata2' from '.../site-packages/unicodedata2.cpython-39-darwin.so'>
```

This PR fixes that by using a fairly standard `try: except ImportError:` guard instead of the `sys.modules` hook.

```
>>> import charset_normalizer
>>> import unicodedata
>>> unicodedata
<module 'unicodedata' from '.../python3.9/lib-dynload/unicodedata.cpython-39-darwin.so'>
```