### PR TITLE
:bug: Fix too small JSON payload triggering md with high ratio

### DIFF
--- a/charset_normalizer/md.py
+++ b/charset_normalizer/md.py
@@ -56,7 +56,7 @@ class TooManySymbolOrPunctuationPlugin(MessDetectorPlugin):
     def feed(self, character: str) -> None:
         self._character_count += 1
 
-        if character != self._last_printable_char and character not in ["<", ">", "=", ":", "/", "&", ";"]:
+        if character != self._last_printable_char and character not in ["<", ">", "=", ":", "/", "&", ";", "{", "}", "[", "]"]:
             if is_punctuation(character):
                 self._punctuation_count += 1
             elif character.isdigit() is False and is_symbol(character):

--- a/tests/test_on_byte.py
+++ b/tests/test_on_byte.py
@@ -27,6 +27,18 @@ class TestBytes(unittest.TestCase):
             len(r.alphabets)
         )
 
+    def test_on_empty_json(self):
+
+        with self.subTest("Detecting empty JSON as ASCII"):
+            results = from_bytes(b"{}").best()
+            self.assertIsNotNone(
+                results.best()
+            )
+            self.assertEqual(
+                results.best().encoding,
+                "ascii"
+            )
+
     def test_bom_detection(self):
         with self.subTest('GB18030 UNAVAILABLE SIG'):
             self.assertFalse(


### PR DESCRIPTION
Close #58~

To reproduce:

```python
from charset_normalizer import from_bytes

results = from_bytes(b"{}").best()
```

Expected encoding = 'ASCII'; Got 'UTF-16 (Variant)'.

Why does this happen?

Because the first pass consists of assessing the "mess/chaos" ratio, and one of the detection plugins was unadjusted for a small JSON payload.
