### PR TITLE
:sparkle: coverage.py revision to verify if binary files are not seen as text

### DIFF
--- a/bin/coverage.py
+++ b/bin/coverage.py
@@ -49,6 +49,11 @@ def cli_coverage(arguments: List[str]):
             preemptive_behaviour=args.preemptive
         )
 
+        if expected_encoding == "None" and len(results) == 0:
+            print("✅✅ '{}'".format(tbt_path))
+            success_count += 1
+            continue
+
         if len(results) == 0:
             print("⚡⚡ '{}' (nothing)".format(tbt_path))
             continue


### PR DESCRIPTION
The data-set just got updated with:

- https://github.com/Ousret/char-dataset/commit/479d9f0ac5a3fa959dc7cbbd6a025fdf615942f8
- https://github.com/Ousret/char-dataset/commit/98583f656f6c3c84ea0346e5b5faa7947ebbd986
- https://github.com/Ousret/char-dataset/commit/9294d8d79ec77db83104fa35f93f8d981fda3065

The `coverage.py` script needed some minor adjustments to verify binary files. (None expected)