### PR TITLE
:wrench: Proper jobs names for workflows

### DIFF
--- a/.github/workflows/chardet-bc.yml
+++ b/.github/workflows/chardet-bc.yml
@@ -3,7 +3,7 @@ name: Chardet BC Coverage
 on: [push, pull_request]
 
 jobs:
-  build:
+  chardet_bc:
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/detector-coverage.yml
+++ b/.github/workflows/detector-coverage.yml
@@ -3,7 +3,7 @@ name: Detection Coverage
 on: [push, pull_request]
 
 jobs:
-  build:
+  detection_coverage:
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integration
 on: [push, pull_request]
 
 jobs:
-  build:
+  downstream:
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -3,7 +3,7 @@ name: Performance Check
 on: [push, pull_request]
 
 jobs:
-  build:
+  performance:
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,13 +3,13 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  build:
+  tests:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10.0-beta.4"]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10.0-rc.1"]
         os: [ubuntu-latest]
         include:
           - python-version: pypy3


### PR DESCRIPTION
Everything was named "build" and could bring some confusion.
The root `name:` is not sufficient.

+ Set Python 3.10.rc.1 (tests)