### PR TITLE
:art: Proper support for static methods that were in v1.x

### DIFF
--- a/charset_normalizer/__init__.py
+++ b/charset_normalizer/__init__.py
@@ -18,17 +18,15 @@ at <https://github.com/Ousret/charset_normalizer>.
 :copyright: (c) 2021 by Ahmed TAHRI
 :license: MIT, see LICENSE for more details.
 """
-import charset_normalizer.api as CharsetDetector
-
 from .api import from_bytes, from_fp, from_path, normalize
-from .legacy import detect
-
-# Backward-compatible v1 imports
-from .models import CharsetMatch, CharsetMatches, CharsetNormalizerMatch
+from .legacy import (
+    CharsetDetector,
+    CharsetNormalizerMatch,
+    CharsetNormalizerMatches,
+    detect,
+)
+from .models import CharsetMatch, CharsetMatches
 from .version import VERSION, __version__
-
-CharsetNormalizerMatches = CharsetDetector
-
 
 __all__ = (
     "from_fp",

--- a/charset_normalizer/__init__.py
+++ b/charset_normalizer/__init__.py
@@ -38,6 +38,7 @@ __all__ = (
     "CharsetMatches",
     "CharsetNormalizerMatch",
     "CharsetNormalizerMatches",
+    "CharsetDetector",
     "__version__",
     "VERSION",
 )

--- a/charset_normalizer/__init__.py
+++ b/charset_normalizer/__init__.py
@@ -21,6 +21,7 @@ at <https://github.com/Ousret/charset_normalizer>.
 from .api import from_bytes, from_fp, from_path, normalize
 from .legacy import (
     CharsetDetector,
+    CharsetDoctor,
     CharsetNormalizerMatch,
     CharsetNormalizerMatches,
     detect,
@@ -39,6 +40,7 @@ __all__ = (
     "CharsetNormalizerMatch",
     "CharsetNormalizerMatches",
     "CharsetDetector",
+    "CharsetDoctor",
     "__version__",
     "VERSION",
 )

--- a/charset_normalizer/legacy.py
+++ b/charset_normalizer/legacy.py
@@ -89,3 +89,7 @@ class CharsetNormalizerMatches(CharsetMatches):
 
 class CharsetDetector(CharsetNormalizerMatches):
     pass
+
+
+class CharsetDoctor(CharsetNormalizerMatches):
+    pass

--- a/charset_normalizer/legacy.py
+++ b/charset_normalizer/legacy.py
@@ -1,7 +1,9 @@
+import warnings
 from typing import Dict, Optional, Union
 
-from .api import from_bytes
+from .api import from_bytes, from_fp, from_path, normalize
 from .constant import CHARDET_CORRESPONDENCE
+from .models import CharsetMatch, CharsetMatches
 
 
 def detect(byte_str: bytes) -> Dict[str, Optional[Union[str, float]]]:
@@ -41,3 +43,49 @@ def detect(byte_str: bytes) -> Dict[str, Optional[Union[str, float]]]:
         "language": language,
         "confidence": confidence,
     }
+
+
+class CharsetNormalizerMatch(CharsetMatch):
+    pass
+
+
+class CharsetNormalizerMatches(CharsetMatches):
+    @staticmethod
+    def from_fp(*args, **kwargs):  # type: ignore
+        warnings.warn(
+            "staticmethod from_fp, from_bytes, from_path and normalize are deprecated "
+            "and scheduled to be removed in 3.0",
+            DeprecationWarning,
+        )
+        return from_fp(*args, **kwargs)
+
+    @staticmethod
+    def from_bytes(*args, **kwargs):  # type: ignore
+        warnings.warn(
+            "staticmethod from_fp, from_bytes, from_path and normalize are deprecated "
+            "and scheduled to be removed in 3.0",
+            DeprecationWarning,
+        )
+        return from_bytes(*args, **kwargs)
+
+    @staticmethod
+    def from_path(*args, **kwargs):  # type: ignore
+        warnings.warn(
+            "staticmethod from_fp, from_bytes, from_path and normalize are deprecated "
+            "and scheduled to be removed in 3.0",
+            DeprecationWarning,
+        )
+        return from_path(*args, **kwargs)
+
+    @staticmethod
+    def normalize(*args, **kwargs):  # type: ignore
+        warnings.warn(
+            "staticmethod from_fp, from_bytes, from_path and normalize are deprecated "
+            "and scheduled to be removed in 3.0",
+            DeprecationWarning,
+        )
+        return normalize(*args, **kwargs)
+
+
+class CharsetDetector(CharsetNormalizerMatches):
+    pass

--- a/charset_normalizer/models.py
+++ b/charset_normalizer/models.py
@@ -380,6 +380,3 @@ class CliDetectionResult:
 
     def to_json(self) -> str:
         return dumps(self.__dict__, ensure_ascii=True, indent=4)
-
-
-CharsetNormalizerMatch = CharsetMatch


### PR DESCRIPTION
Something was not quite right with the v1 support regarding:

- `CharsetNormalizerMatches.from_bytes`
- `CharsetNormalizerMatches.from_fp`
- `CharsetNormalizerMatches.from_path`
- `CharsetNormalizerMatches.normalize`

This PR provides a better/cleaner implt.