### PR TITLE
🍱 Add missing package_data kwarg in setup.py for 'py.typed'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
+    package_data={"charset_normalizer": ["py.typed"]},
     license='MIT',
     entry_points={
         'console_scripts':


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0561/#id18

