### PR TITLE
Add bytearray type chk in from_bytes function

### DIFF
--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -62,9 +62,11 @@ def from_bytes(
     This function will strip the SIG in the payload/sequence every time except on UTF-16, UTF-32.
     """
 
-    if not isinstance(sequences, bytes):
+    if not isinstance(sequences, (bytearray, bytes)):
         raise TypeError(
-            "Expected object of type bytes, got: {0}".format(type(sequences))
+            "Expected object of type bytes or bytearray, got: {0}".format(
+                type(sequences)
+            )
         )
 
     if not explain:


### PR DESCRIPTION
Following commit abcb49a9c297590b45aef721bcd64400919d8ea9 
I forgot to add `bytearray` to acceptable types in the `from_bytes` function. 