### PR TITLE
:sparkle: Improve chunk extraction with multi-byte string

### DIFF
--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -276,7 +276,17 @@ def from_bytes(
         md_ratios = []
 
         for i in r_:
-            cut_sequence = sequences[i : i + chunk_size]
+            # If current encoding support multi-byte character, we want to adjust the initial
+            # index cutting. The end does not matter. Remember that there is no reliable method
+            # to find high byte for every conceivable code page. We do our best.
+            if is_multi_byte_decoder and i > 0 and sequences[i] > 128:
+                adjusted_offset, max_value = i, sequences[i]
+                for y in range(i, i - 4):
+                    if sequences[y] > max_value:
+                        adjusted_offset, max_value = y, sequences[y]
+                cut_sequence = sequences[adjusted_offset : i + chunk_size]
+            else:
+                cut_sequence = sequences[i : i + chunk_size]
 
             if bom_or_sig_available and strip_sig_or_bom is False:
                 cut_sequence = sig_payload + cut_sequence


### PR DESCRIPTION
Abstract
---------

When `charset_normalizer` measure the mess/coherence in a given byte sequence for a given encoding, it extract small chunks of data.
Sometime, due to bad luck, it could split the data at the wrong initial index causing the rendered str (for the chunk) to be gibberish.

This PR address that problem and try to find the appropriate start index. WiP.