### PR TITLE
:fire: Remove the warning (about small content) in favor of a simple logging.warning

### DIFF
--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -9,7 +9,6 @@ except ImportError:
     PathLike = Union[str, "os.PathLike[str]"]  # type: ignore
 
 import logging
-from warnings import warn
 
 from .cd import (
     coherence_ratio,
@@ -119,8 +118,14 @@ def from_bytes(
     is_too_large_sequence = len(sequences) >= TOO_BIG_SEQUENCE  # type: bool
 
     if is_too_small_sequence:
-        warn(
+        logger.warning(
             "Trying to detect encoding from a tiny portion of ({}) byte(s).".format(
+                length
+            )
+        )
+    elif is_too_large_sequence:
+        logger.info(
+            "Using lazy str decoding because the payload is quite large, ({}) byte(s).".format(
                 length
             )
         )


### PR DESCRIPTION
…

Raising a warning is a bit excessive and seems to bother more than it helped.
The general idea of a warning should be that its fixable by the end user/lib. Most of the time its not.
