### PR TITLE
:sparkle: Small improvement over Unicode detection

### DIFF
--- a/charset_normalizer/md.py
+++ b/charset_normalizer/md.py
@@ -7,6 +7,7 @@ from .utils import (
     is_ascii,
     is_case_variable,
     is_cjk,
+    is_emoticon,
     is_hangul,
     is_hiragana,
     is_katakana,
@@ -87,7 +88,11 @@ class TooManySymbolOrPunctuationPlugin(MessDetectorPlugin):
         ]:
             if is_punctuation(character):
                 self._punctuation_count += 1
-            elif character.isdigit() is False and is_symbol(character):
+            elif (
+                character.isdigit() is False
+                and is_symbol(character)
+                and is_emoticon(character) is False
+            ):
                 self._symbol_count += 2
 
         self._last_printable_char = character

--- a/charset_normalizer/models.py
+++ b/charset_normalizer/models.py
@@ -57,9 +57,16 @@ class CharsetMatch:
 
         # Bellow 1% difference --> Use Coherence
         if chaos_difference < 0.01:
+            # When having a tough decision, use the result that decoded as many multi-byte as possible.
+            if chaos_difference == 0.0 and self.coherence == other.coherence:
+                return self.multi_byte_usage > other.multi_byte_usage
             return self.coherence > other.coherence
 
         return self.chaos < other.chaos
+
+    @property
+    def multi_byte_usage(self) -> float:
+        return 1.0 - len(str(self)) / len(self.raw)
 
     @property
     def chaos_secondary_pass(self) -> float:

--- a/charset_normalizer/utils.py
+++ b/charset_normalizer/utils.py
@@ -111,6 +111,16 @@ def is_symbol(character: str) -> bool:
 
 
 @lru_cache(maxsize=UTF8_MAXIMAL_ALLOCATION)
+def is_emoticon(character: str) -> bool:
+    character_range = unicode_range(character)  # type: Optional[str]
+
+    if character_range is None:
+        return False
+
+    return "Emoticons" in character_range
+
+
+@lru_cache(maxsize=UTF8_MAXIMAL_ALLOCATION)
 def is_separator(character: str) -> bool:
     if character.isspace() or character in ["｜", "+", ",", ";", "<", ">"]:
         return True

--- a/tests/test_base_detection.py
+++ b/tests/test_base_detection.py
@@ -83,7 +83,8 @@ def test_obviously_ascii_content(payload):
         "(° ͜ʖ °), creepy face, smiley 😀".encode("utf_8"),
         """["Financiën", "La France"]""".encode("utf_8"),
         "Qu'est ce que une étoile?".encode("utf_8"),
-        """<?xml ?><c>Financiën</c>""".encode("utf_8")
+        """<?xml ?><c>Financiën</c>""".encode("utf_8"),
+        "😀".encode("utf_8")
     ]
 )
 def test_obviously_utf8_content(payload):


### PR DESCRIPTION
Tiny improvement that allow small Unicode payload to be detected with more accuracy.

```python
import charset_normalizer

payload = "😀".encode("utf_8")

results = from_bytes(payload)

print(results.best().encoding)  # print "utf_8"!
```

chardet has trouble with those cases. Any Unicode payload containing emoticons makes the detection fail. Probably their prober that need to be retrained with more up-to-date stats.

```
>>> chardet.detect("😀".encode("utf_8"))
{'encoding': None, 'confidence': 0.0, 'language': None}
```

That a tiny improvement but noticeable/appreciable.

