### PR TITLE
❇️ Improve chunk extraction with multi-byte string

### DIFF
--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -292,9 +292,14 @@ def from_bytes(
             # not the cleanest way to perform that fix but clever enough for now.
             if is_multi_byte_decoder and i > 0 and sequences[i] >= 0x80:
 
-                chunk_partial_size_chk = 16 if chunk_size > 16 else chunk_size  # type: int
+                chunk_partial_size_chk = (
+                    16 if chunk_size > 16 else chunk_size
+                )  # type: int
 
-                if decoded_payload and chunk[:chunk_partial_size_chk] not in decoded_payload:
+                if (
+                    decoded_payload
+                    and chunk[:chunk_partial_size_chk] not in decoded_payload
+                ):
                     for j in range(i, i - 4, -1):
                         cut_sequence = sequences[j : i + chunk_size]
 

--- a/tests/test_base_detection.py
+++ b/tests/test_base_detection.py
@@ -92,3 +92,16 @@ def test_obviously_utf8_content(payload):
 
     assert best_guess is not None, "Dead-simple UTF-8 detection has failed!"
     assert best_guess.encoding == "utf_8", "Dead-simple UTF-8 detection is wrongly detected!"
+
+
+def test_mb_cutting_chk():
+    # This payload should be wrongfully split and the autofix should ran automatically
+    # on chunks extraction.
+    payload = b"\xbf\xaa\xbb\xe7\xc0\xfb    \xbf\xb9\xbc\xf6 " \
+              b"   \xbf\xac\xb1\xb8\xc0\xda\xb5\xe9\xc0\xba  \xba\xb9\xc0\xbd\xbc\xad\xb3\xaa " * 128
+
+    guesses = from_bytes(payload, cp_isolation=["cp949"])
+    best_guess = guesses.best()
+
+    assert len(guesses) == 1, "cp isolation is set and given seq should be clear CP949!"
+    assert best_guess.encoding == "cp949"


### PR DESCRIPTION
Second attempt following draft #90 

Abstract
---------

When `charset_normalizer` measure the mess/coherence in a given byte sequence for a given encoding, it extract small chunks of data.
Sometime, due to bad luck, it could split the data at the wrong initial index causing the rendered str (for the chunk) to be gibberish.

This PR address that problem and try to find the appropriate start index. 

