### PR TITLE
:bug: Fix ImportError that could occurs on older Python 3.5.x

### DIFF
--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -1,12 +1,10 @@
 from os.path import basename, splitext
-from typing import BinaryIO, List, Optional, Set, Union
+from typing import BinaryIO, List, Optional, Set
 
 try:
     from os import PathLike
 except ImportError:
-    import os
-
-    PathLike = Union[str, "os.PathLike[str]"]  # type: ignore
+    PathLike = str  # type: ignore
 
 import logging
 

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -3,7 +3,7 @@ from typing import BinaryIO, List, Optional, Set
 
 try:
     from os import PathLike
-except ImportError:
+except ImportError:  # pragma: no cover
     PathLike = str  # type: ignore
 
 import logging


### PR DESCRIPTION
First discovered by https://github.com/ros-infrastructure/ros_buildfarm/pull/905 Not all Python 3.5.x are concerned. Latest minor is OK (3.5.10).

Was very unexpected. This PR should fix that promptly.