### PR TITLE
:bug: Fix CLI when using --minimal output in certain cases

### DIFF
--- a/charset_normalizer/cli/normalizer.py
+++ b/charset_normalizer/cli/normalizer.py
@@ -195,7 +195,7 @@ def cli_detect(argv: List[str] = None) -> int:
 
             if len(matches) > 1 and args.alternatives:
                 for el in matches:
-                    if el != matches:
+                    if el != best_guess:
                         x_.append(
                             CliDetectionResult(
                                 abspath(my_file.name),
@@ -273,7 +273,16 @@ def cli_detect(argv: List[str] = None) -> int:
             )
         )
     else:
-        print(", ".join([el.encoding if el.encoding else "undefined" for el in x_]))
+        for my_file in args.files:
+            print(
+                ", ".join(
+                    [
+                        el.encoding if el.encoding else "undefined"
+                        for el in x_
+                        if el.path == abspath(my_file.name)
+                    ]
+                )
+            )
 
     return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,46 @@ class TestCommandLineInterface(unittest.TestCase):
             )
         )
 
+    def test_with_alternative(self):
+        self.assertEqual(
+            0,
+            cli_detect(
+                [
+                    '-a',
+                    './data/sample.1.ar.srt',
+                    './data/sample.1.he.srt',
+                    './data/sample-chinese.txt'
+                ]
+            )
+        )
+
+    def test_with_minimal_output(self):
+        self.assertEqual(
+            0,
+            cli_detect(
+                [
+                    '-m',
+                    './data/sample.1.ar.srt',
+                    './data/sample.1.he.srt',
+                    './data/sample-chinese.txt'
+                ]
+            )
+        )
+
+    def test_with_minimal_and_alt(self):
+        self.assertEqual(
+            0,
+            cli_detect(
+                [
+                    '-m',
+                    '-a',
+                    './data/sample.1.ar.srt',
+                    './data/sample.1.he.srt',
+                    './data/sample-chinese.txt'
+                ]
+            )
+        )
+
     def test_non_existent_file(self):
 
         with self.assertRaises(SystemExit) as cm:


### PR DESCRIPTION
Happen when used with -a (alternative)

Here is the traceback

```
(venv) [ahmed@fedora charset_normalizer]$ normalizer -a -m ./data/sample.1.fr.srt 
Traceback (most recent call last):
  File "/home/ahmed/PycharmProjects/charset_normalizer/venv/bin/normalizer", line 33, in <module>
    sys.exit(load_entry_point('charset-normalizer==2.0.6', 'console_scripts', 'normalizer')())
  File "/home/ahmed/PycharmProjects/charset_normalizer/venv/lib/python3.9/site-packages/charset_normalizer-2.0.6-py3.9.egg/charset_normalizer/cli/normalizer.py", line 198, in cli_detect
  File "/home/ahmed/PycharmProjects/charset_normalizer/venv/lib/python3.9/site-packages/charset_normalizer-2.0.6-py3.9.egg/charset_normalizer/models.py", line 42, in __eq__
TypeError: __eq__ cannot be invoked on <class 'charset_normalizer.models.CharsetMatches'> and <class 'charset_normalizer.models.CharsetMatch'>.
```

In addition to the actual bugfix, the minimal output was confusing as when using multiple files in args, the results were on the same line. 

Before:

```
(venv) [ahmed@fedora charset_normalizer]$ normalizer -a -m ./data/sample.1.fr.srt 
cp1252, cp775, mac_latin2, cp1250, cp1257, iso8859_10, cp852, hp_roman8, cp850, cp1125, cp1251, cp855, cp866, iso8859_5, koi8_r, cp1253, cp437, cp864, cp869, iso8859_11, mac_greek, mac_iceland, mac_roman
(venv) [ahmed@fedora charset_normalizer]$ normalizer -a -m ./data/sample.1.fr.srt ./data/sample.1.ar.srt 
cp1252, cp775, mac_latin2, cp1250, cp1257, iso8859_10, cp852, hp_roman8, cp850, cp1125, cp1251, cp855, cp866, iso8859_5, koi8_r, cp1253, cp437, cp864, cp869, iso8859_11, mac_greek, mac_iceland, mac_roman, cp1256, cp1251, kz1048, ptcp154, iso8859_5
```

After:

```
(venv) [ahmed@fedora charset_normalizer]$ normalizer -a -m ./data/sample.1.fr.srt ./data/sample.1.ar.srt 
cp1252, cp775, mac_latin2, cp1250, cp1257, iso8859_10, cp852, hp_roman8, cp850, cp1125, cp1251, cp855, cp866, iso8859_5, koi8_r, cp1253, cp437, cp864, cp869, iso8859_11, mac_greek, mac_iceland, mac_roman
cp1256, cp1251, kz1048, ptcp154, iso8859_5
(venv) [ahmed@fedora charset_normalizer]$ normalizer -m ./data/sample.1.fr.srt ./data/sample.1.ar.srt 
cp1252
cp1256
```

