### PR TITLE
:wrench: Trying to leverage PEP263 when PEP3120 is ignored

### DIFF
--- a/charset_normalizer/__init__.py
+++ b/charset_normalizer/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf_8 -*-
 """
 Charset-Normalizer
 ~~~~~~~~~~~~~~

--- a/charset_normalizer/assets/__init__.py
+++ b/charset_normalizer/assets/__init__.py
@@ -1,10 +1,4 @@
-"""
-This submodule purpose is to load attached JSON asset.
-Will be loaded once per package import / python init.
-
-The file 'frequencies.json' is mandatory for language/coherence detection. Not having it will weaker considerably
-the core detection.
-"""
+# -*- coding: utf_8 -*-
 from collections import OrderedDict
 
 FREQUENCIES = OrderedDict(


### PR DESCRIPTION
Following #114 

Some Python environment override the default source encoding and its a problem when used with `charset_normalizer`.
More context available cf. https://bugs.python.org/issue29240

- `charset_normalizer/__init__.py`
- `charset_normalizer/assets/__init__.py`

Add the encoding tag.