### PR TITLE
call sum() without an intermediary list following PEP 289 recommendations

### DIFF
--- a/charset_normalizer/cd.py
+++ b/charset_normalizer/cd.py
@@ -324,7 +324,7 @@ def coherence_ratio(
         sequence_frequencies = Counter(layer)  # type: Counter
         most_common = sequence_frequencies.most_common()
 
-        character_count = sum([o for c, o in most_common])  # type: int
+        character_count = sum(o for c, o in most_common)  # type: int
 
         if character_count <= TOO_SMALL_SEQUENCE:
             continue

--- a/charset_normalizer/md.py
+++ b/charset_normalizer/md.py
@@ -538,7 +538,7 @@ def mess_ratio(
         if (
             index > 0 and index % intermediary_mean_mess_ratio_calc == 0
         ) or index == length - 1:
-            mean_mess_ratio = sum([dt.ratio for dt in detectors])
+            mean_mess_ratio = sum(dt.ratio for dt in detectors)
 
             if mean_mess_ratio >= maximum_threshold:
                 break


### PR DESCRIPTION
Just a simple syntax issue, `sum()` doesn't need prior casting of iterables to a list, a generator expression is better from a memory standpoint, see [PEP 289](https://www.python.org/dev/peps/pep-0289/).