### PR TITLE
Fix wrong logging level applied when setting kwarg `explain` to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - [Short description of non-trivial change.]
 
+### Fixed
+- Wrong logging level applied when setting kwarg `explain` to True (PR #146)
+
 ## [2.0.8](https://github.com/Ousret/charset_normalizer/compare/2.0.7...2.0.8) (2021-11-24)
 ### Changed
 - Improvement over Vietnamese detection (PR #126)

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -68,7 +68,7 @@ def from_bytes(
         )
 
     if explain:
-        previous_logger_level = logger.level  # type: Optional[int]
+        previous_logger_level = logger.level  # type: int
         logger.addHandler(explain_handler)
         logger.setLevel(logging.INFO)
 
@@ -422,7 +422,7 @@ def from_bytes(
             )
             if explain:
                 logger.removeHandler(explain_handler)
-                logger.setLevel(previous_logger_level or logging.WARNING)
+                logger.setLevel(previous_logger_level)
             return CharsetMatches([results[encoding_iana]])
 
         if encoding_iana == sig_encoding:
@@ -432,7 +432,7 @@ def from_bytes(
             )
             if explain:
                 logger.removeHandler(explain_handler)
-                logger.setLevel(previous_logger_level or logging.WARNING)
+                logger.setLevel(previous_logger_level)
             return CharsetMatches([results[encoding_iana]])
 
     if len(results) == 0:
@@ -463,7 +463,7 @@ def from_bytes(
 
     if explain:
         logger.removeHandler(explain_handler)
-        logger.setLevel(previous_logger_level or logging.WARNING)
+        logger.setLevel(previous_logger_level)
 
     return results
 

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -80,7 +80,7 @@ def from_bytes(
         )
         if explain:
             logger.removeHandler(explain_handler)
-            logger.setLevel(previous_logger_level)
+            logger.setLevel(previous_logger_level or logging.WARNING)
         return CharsetMatches([CharsetMatch(sequences, "utf_8", 0.0, False, [], "")])
 
     if cp_isolation is not None:
@@ -422,7 +422,7 @@ def from_bytes(
             )
             if explain:
                 logger.removeHandler(explain_handler)
-                logger.setLevel(previous_logger_level)
+                logger.setLevel(previous_logger_level or logging.WARNING)
             return CharsetMatches([results[encoding_iana]])
 
         if encoding_iana == sig_encoding:
@@ -432,7 +432,7 @@ def from_bytes(
             )
             if explain:
                 logger.removeHandler(explain_handler)
-                logger.setLevel(previous_logger_level)
+                logger.setLevel(previous_logger_level or logging.WARNING)
             return CharsetMatches([results[encoding_iana]])
 
     if len(results) == 0:
@@ -463,7 +463,7 @@ def from_bytes(
 
     if explain:
         logger.removeHandler(explain_handler)
-        logger.setLevel(previous_logger_level)
+        logger.setLevel(previous_logger_level or logging.WARNING)
 
     return results
 

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -68,7 +68,9 @@ def from_bytes(
         )
 
     if explain:
+        previous_logger_level = logger.level  # type: int
         logger.addHandler(explain_handler)
+        logger.setLevel(logging.INFO)
 
     length = len(sequences)  # type: int
 
@@ -78,6 +80,7 @@ def from_bytes(
         )
         if explain:
             logger.removeHandler(explain_handler)
+            logger.setLevel(previous_logger_level)
         return CharsetMatches([CharsetMatch(sequences, "utf_8", 0.0, False, [], "")])
 
     if cp_isolation is not None:
@@ -419,6 +422,7 @@ def from_bytes(
             )
             if explain:
                 logger.removeHandler(explain_handler)
+                logger.setLevel(previous_logger_level)
             return CharsetMatches([results[encoding_iana]])
 
         if encoding_iana == sig_encoding:
@@ -428,6 +432,7 @@ def from_bytes(
             )
             if explain:
                 logger.removeHandler(explain_handler)
+                logger.setLevel(previous_logger_level)
             return CharsetMatches([results[encoding_iana]])
 
     if len(results) == 0:
@@ -458,6 +463,7 @@ def from_bytes(
 
     if explain:
         logger.removeHandler(explain_handler)
+        logger.setLevel(previous_logger_level)
 
     return results
 

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -68,7 +68,7 @@ def from_bytes(
         )
 
     if explain:
-        previous_logger_level = logger.level  # type: int
+        previous_logger_level = logger.level  # type: Optional[int]
         logger.addHandler(explain_handler)
         logger.setLevel(logging.INFO)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,7 +10,7 @@ class TestLogBehaviorClass:
         self.logger = logging.getLogger("charset_normalizer")
         self.logger.handlers.clear()
         self.logger.addHandler(logging.NullHandler())
-        self.logger.level = None
+        self.logger.level = logging.WARNING
 
     def test_explain_true_behavior(self, caplog):
         test_sequence = b'This is a test sequence of bytes that should be sufficient'


### PR DESCRIPTION
Following PR #135 , accidentally introduced a small regression.