### PR TITLE
:wrench: Skipping CD on ASCII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fallback match entries might lead to UnicodeDecodeError for large bytes sequence (PR #154)
 
+### Changed
+- Skipping the language-detection (CD) on ASCII (PR #155)
+
 ## [2.0.9](https://github.com/Ousret/charset_normalizer/compare/2.0.8...2.0.9) (2021-12-03)
 
 ### Changed

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -385,7 +385,7 @@ def from_bytes(
             target_languages = mb_encoding_languages(encoding_iana)
 
         if target_languages:
-            logger.info(
+            logger.debug(
                 "{} should target any language(s) of {}".format(
                     encoding_iana, str(target_languages)
                 )
@@ -427,7 +427,7 @@ def from_bytes(
             encoding_iana in [specified_encoding, "ascii", "utf_8"]
             and mean_mess_ratio < 0.1
         ):
-            logger.debug(
+            logger.info(
                 "%s is most likely the one. Stopping the process.", encoding_iana
             )
             if explain:
@@ -436,7 +436,7 @@ def from_bytes(
             return CharsetMatches([results[encoding_iana]])
 
         if encoding_iana == sig_encoding:
-            logger.debug(
+            logger.info(
                 "%s is most likely the one as we detected a BOM or SIG within the beginning of the sequence.",
                 encoding_iana,
             )

--- a/charset_normalizer/api.py
+++ b/charset_normalizer/api.py
@@ -395,7 +395,7 @@ def from_bytes(
 
         # We shall skip the CD when its about ASCII
         # Most of the time its not relevant to run "language-detection" on it.
-        if encoding_iana != 'ascii':
+        if encoding_iana != "ascii":
             for chunk in md_chunks:
                 chunk_languages = coherence_ratio(
                     chunk, 0.1, ",".join(target_languages) if target_languages else None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -17,7 +17,7 @@ class TestLogBehaviorClass:
         from_bytes(test_sequence, steps=1, chunk_size=50, explain=True)
         assert explain_handler not in self.logger.handlers
         for record in caplog.records:
-            assert record.levelname == "INFO"
+            assert record.levelname in ["INFO", "DEBUG"]
 
     def test_explain_false_handler_set_behavior(self, caplog):
         test_sequence = b'This is a test sequence of bytes that should be sufficient'
@@ -25,7 +25,7 @@ class TestLogBehaviorClass:
         from_bytes(test_sequence, steps=1, chunk_size=50, explain=False)
         assert any(isinstance(hdl, logging.StreamHandler) for hdl in self.logger.handlers)
         for record in caplog.records:
-            assert record.levelname == "INFO"
+            assert record.levelname in ["INFO", "DEBUG"]
         assert "ascii is most likely the one. Stopping the process." in caplog.text
 
     def test_set_stream_handler(self, caplog):
@@ -34,7 +34,7 @@ class TestLogBehaviorClass:
         )
         self.logger.debug("log content should log with default format")
         for record in caplog.records:
-            assert record.levelname == "DEBUG"
+            assert record.levelname in ["INFO", "DEBUG"]
         assert "log content should log with default format" in caplog.text
 
     def test_set_stream_handler_format(self, caplog):


### PR DESCRIPTION
The language detection (CD) on ASCII is often useless. With this PR we skip it and globally improve performance.