### PR TITLE
Add explicit support for Python 3.11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-alpha.4"]
         os: [ubuntu-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - [Short description of non-trivial change.]
 
+### Added
+- Explicit support for Python 3.11 (PR #164)
+
 ### Changed
 - The logging behavior have been completely reviewed, now using only TRACE and DEBUG levels (PR #163)
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Text Processing :: Linguistic',
         'Topic :: Utilities',
         'Programming Language :: Python :: Implementation :: PyPy',


### PR DESCRIPTION
From Python 3.11 CHANGES.

- The Unicode database has been updated to version 14.0.0. (bpo-45190).
