### PR TITLE
Release 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [2.0.12.dev0](https://github.com/Ousret/charset_normalizer/compare/2.0.11...master) (unreleased)
+## [2.0.12](https://github.com/Ousret/charset_normalizer/compare/2.0.11...2.0.12) (2022-02-12)
 
 ### Fixed
-- Improved ASCII detection (PR #170) 
+- ASCII miss-detection on rare cases (PR #170) 
 
 ## [2.0.11](https://github.com/Ousret/charset_normalizer/compare/2.0.10...2.0.11) (2022-01-30)
 

--- a/bin/bc.py
+++ b/bin/bc.py
@@ -43,7 +43,7 @@ def cli_bc(arguments: List[str]):
     success_count = 0
     total_count = 0
 
-    for tbt_path in glob("./char-dataset/**/*.*"):
+    for tbt_path in sorted(glob("./char-dataset/**/*.*")):
         total_count += 1
 
         with open(tbt_path, "rb") as fp:

--- a/bin/coverage.py
+++ b/bin/coverage.py
@@ -43,7 +43,7 @@ def cli_coverage(arguments: List[str]):
     success_count = 0
     total_count = 0
 
-    for tbt_path in glob("./char-dataset/**/*.*"):
+    for tbt_path in sorted(glob("./char-dataset/**/*.*")):
 
         expected_encoding = tbt_path.split(sep)[-2]
         total_count += 1

--- a/bin/performance.py
+++ b/bin/performance.py
@@ -37,7 +37,7 @@ def performance_compare(arguments):
     chardet_results = []
     charset_normalizer_results = []
 
-    for tbt_path in glob("./char-dataset/**/*.*"):
+    for tbt_path in sorted(glob("./char-dataset/**/*.*")):
         print(tbt_path)
 
         # Read Bin file

--- a/bin/serve.py
+++ b/bin/serve.py
@@ -13,7 +13,7 @@ def read_file(path):
 def read_targets():
     return jsonify(
         [
-            el.replace("./char-dataset", "/raw").replace("\\", "/") for el in glob("./char-dataset/**/*")
+            el.replace("./char-dataset", "/raw").replace("\\", "/") for el in sorted(glob("./char-dataset/**/*"))
         ]
     )
 

--- a/charset_normalizer/version.py
+++ b/charset_normalizer/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "2.0.12.dev0"
+__version__ = "2.0.12"
 VERSION = __version__.split(".")


### PR DESCRIPTION
Originally, some _master_ playlists (m3u) were miss-detected. This release will prevent the downstream users to be unable to read properly some streams. More on that, see the related PR.

## [2.0.12](https://github.com/Ousret/charset_normalizer/compare/2.0.11...2.0.12) (2022-02-12)

### Fixed
- ASCII miss-detection on rare cases (PR #170) 

