### PR TITLE
Test latest Python 3.11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-alpha.4"]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
[Python 3.11.0b1 is now available!](https://discuss.python.org/t/python-3-11-0b1-is-now-available/15602?u=hugovk)

Rather than specify alpha 4 as the upper limit on the CI, `3.11-dev` will track the latest available alpha/beta/RC.

(Full release is expected in October.)

# Demo

https://github.com/hugovk/charset_normalizer/runs/6342369089?check_suite_focus=true