### PR TITLE
:sparkle: Add unicode version output in CLI --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [2.1.0.dev0](https://github.com/Ousret/charset_normalizer/compare/2.0.12...master) (2022-??-??)
 
+### Added
+- Output the Unicode table version when running the CLI with `--version` (PR #194)
+
 ### Changed
 - Re-use decoded buffer for single byte character sets from [@nijel](https://github.com/nijel) (PR #175)
 - Fixing some performance bottlenecks from [@deedy5](https://github.com/deedy5) (PR #183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - Support for Python 3.5 (PR #192)
 
+### Deprecated
+- Use of backport unicodedata from `unicodedata2` as Python is quickly catching up, scheduled for removal in 3.0 (PR #194)
+
 ## [2.0.12](https://github.com/Ousret/charset_normalizer/compare/2.0.11...2.0.12) (2022-02-12)
 
 ### Fixed

--- a/charset_normalizer/cli/normalizer.py
+++ b/charset_normalizer/cli/normalizer.py
@@ -5,6 +5,11 @@ from os.path import abspath
 from platform import python_version
 from typing import List
 
+try:
+    from unicodedata2 import unidata_version
+except ImportError:
+    from unicodedata import unidata_version
+
 from charset_normalizer import from_fp
 from charset_normalizer.models import CliDetectionResult
 from charset_normalizer.version import __version__
@@ -119,8 +124,8 @@ def cli_detect(argv: List[str] = None) -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="Charset-Normalizer {} - Python {}".format(
-            __version__, python_version()
+        version="Charset-Normalizer {} - Python {} - Unicode {}".format(
+            __version__, python_version(), unidata_version
         ),
         help="Show version information and exit.",
     )

--- a/charset_normalizer/utils.py
+++ b/charset_normalizer/utils.py
@@ -1,4 +1,6 @@
 try:
+    # WARNING: unicodedata2 support is going to be removed in 3.0
+    # Python is quickly catching up.
     import unicodedata2 as unicodedata
 except ImportError:
     import unicodedata  # type: ignore[no-redef]


### PR DESCRIPTION
And deprecate the use of unicodedata2