### PR TITLE
Marking constants as Final

### DIFF
--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -2,7 +2,7 @@ import sys
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
 from encodings.aliases import aliases
 from re import IGNORECASE, compile as re_compile
-from typing import Dict, List, Pattern, Set, Union
+from typing import Dict, List, Set, Union
 
 if sys.version_info <= (3, 8):
     from typing_extensions import Final
@@ -332,7 +332,7 @@ UNICODE_SECONDARY_RANGE_KEYWORD: Final[List[str]] = [
     "Tags",
 ]
 
-RE_POSSIBLE_ENCODING_INDICATION: Final[Pattern[str]] = re_compile(
+RE_POSSIBLE_ENCODING_INDICATION: Final = re_compile(
     r"(?:(?:encoding)|(?:charset)|(?:coding))(?:[\:= ]{1,10})(?:[\"\']?)([a-zA-Z0-9\-_]+)(?:[\"\']?)",
     IGNORECASE,
 )

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -1,12 +1,12 @@
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
 from encodings.aliases import aliases
 from re import IGNORECASE, compile as re_compile
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Set, Union, Final
 
 from .assets import FREQUENCIES
 
 # Contain for each eligible encoding a list of/item bytes SIG/BOM
-ENCODING_MARKS: Dict[str, Union[bytes, List[bytes]]] = {
+ENCODING_MARKS: Final[Dict[str, Union[bytes, List[bytes]]]] = {
     "utf_8": BOM_UTF8,
     "utf_7": [
         b"\x2b\x2f\x76\x38",
@@ -20,12 +20,12 @@ ENCODING_MARKS: Dict[str, Union[bytes, List[bytes]]] = {
     "utf_16": [BOM_UTF16_BE, BOM_UTF16_LE],
 }
 
-TOO_SMALL_SEQUENCE: int = 32
-TOO_BIG_SEQUENCE: int = int(10e6)
+TOO_SMALL_SEQUENCE: Final[int] = 32
+TOO_BIG_SEQUENCE: Final[int] = int(10e6)
 
-UTF8_MAXIMAL_ALLOCATION: int = 1112064
+UTF8_MAXIMAL_ALLOCATION: Final[int] = 1112064
 
-UNICODE_RANGES_COMBINED: Dict[str, range] = {
+UNICODE_RANGES_COMBINED: Final[Dict[str, range]] = {
     "Control character": range(31 + 1),
     "Basic Latin": range(32, 127 + 1),
     "Latin-1 Supplement": range(128, 255 + 1),
@@ -308,7 +308,7 @@ UNICODE_RANGES_COMBINED: Dict[str, range] = {
 }
 
 
-UNICODE_SECONDARY_RANGE_KEYWORD: List[str] = [
+UNICODE_SECONDARY_RANGE_KEYWORD: Final[List[str]] = [
     "Supplement",
     "Extended",
     "Extensions",
@@ -326,12 +326,12 @@ UNICODE_SECONDARY_RANGE_KEYWORD: List[str] = [
     "Tags",
 ]
 
-RE_POSSIBLE_ENCODING_INDICATION = re_compile(
+RE_POSSIBLE_ENCODING_INDICATION: Final = re_compile(
     r"(?:(?:encoding)|(?:charset)|(?:coding))(?:[\:= ]{1,10})(?:[\"\']?)([a-zA-Z0-9\-_]+)(?:[\"\']?)",
     IGNORECASE,
 )
 
-IANA_SUPPORTED: List[str] = sorted(
+IANA_SUPPORTED: Final[List[str]] = sorted(
     filter(
         lambda x: x.endswith("_codec") is False
         and x not in {"rot_13", "tactis", "mbcs"},
@@ -339,10 +339,10 @@ IANA_SUPPORTED: List[str] = sorted(
     )
 )
 
-IANA_SUPPORTED_COUNT: int = len(IANA_SUPPORTED)
+IANA_SUPPORTED_COUNT: Final[int] = len(IANA_SUPPORTED)
 
 # pre-computed code page that are similar using the function cp_similarity.
-IANA_SUPPORTED_SIMILAR: Dict[str, List[str]] = {
+IANA_SUPPORTED_SIMILAR: Final[Dict[str, List[str]]] = {
     "cp037": ["cp1026", "cp1140", "cp273", "cp500"],
     "cp1026": ["cp037", "cp1140", "cp273", "cp500"],
     "cp1125": ["cp866"],
@@ -431,7 +431,7 @@ IANA_SUPPORTED_SIMILAR: Dict[str, List[str]] = {
 }
 
 
-CHARDET_CORRESPONDENCE: Dict[str, str] = {
+CHARDET_CORRESPONDENCE: Final[Dict[str, str]] = {
     "iso2022_kr": "ISO-2022-KR",
     "iso2022_jp": "ISO-2022-JP",
     "euc_kr": "EUC-KR",
@@ -467,7 +467,7 @@ CHARDET_CORRESPONDENCE: Dict[str, str] = {
 }
 
 
-COMMON_SAFE_ASCII_CHARACTERS: Set[str] = {
+COMMON_SAFE_ASCII_CHARACTERS: Final[Set[str]] = {
     "<",
     ">",
     "=",
@@ -486,10 +486,10 @@ COMMON_SAFE_ASCII_CHARACTERS: Set[str] = {
 }
 
 
-KO_NAMES: Set[str] = {"johab", "cp949", "euc_kr"}
-ZH_NAMES: Set[str] = {"big5", "cp950", "big5hkscs", "hz"}
+KO_NAMES: Final[Set[str]] = {"johab", "cp949", "euc_kr"}
+ZH_NAMES: Final[Set[str]] = {"big5", "cp950", "big5hkscs", "hz"}
 
-LANGUAGE_SUPPORTED_COUNT: int = len(FREQUENCIES)
+LANGUAGE_SUPPORTED_COUNT: Final[int] = len(FREQUENCIES)
 
 # Logging LEVEL bellow DEBUG
-TRACE: int = 5
+TRACE: Final[int] = 5

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -1,7 +1,13 @@
+import sys
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
 from encodings.aliases import aliases
 from re import IGNORECASE, compile as re_compile
-from typing import Dict, Final, List, Set, Union
+from typing import Dict, List, Set, Union
+
+if sys.version_info <= (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
 
 from .assets import FREQUENCIES
 

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -332,7 +332,7 @@ UNICODE_SECONDARY_RANGE_KEYWORD: Final[List[str]] = [
     "Tags",
 ]
 
-RE_POSSIBLE_ENCODING_INDICATION: Final[Pattern] = re_compile(
+RE_POSSIBLE_ENCODING_INDICATION: Final[Pattern[str]] = re_compile(
     r"(?:(?:encoding)|(?:charset)|(?:coding))(?:[\:= ]{1,10})(?:[\"\']?)([a-zA-Z0-9\-_]+)(?:[\"\']?)",
     IGNORECASE,
 )

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -1,7 +1,7 @@
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
 from encodings.aliases import aliases
 from re import IGNORECASE, compile as re_compile
-from typing import Dict, List, Set, Union, Final
+from typing import Dict, Final, List, Set, Union
 
 from .assets import FREQUENCIES
 

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -2,7 +2,7 @@ import sys
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
 from encodings.aliases import aliases
 from re import IGNORECASE, compile as re_compile
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Pattern, Set, Union
 
 if sys.version_info <= (3, 8):
     from typing_extensions import Final
@@ -332,7 +332,7 @@ UNICODE_SECONDARY_RANGE_KEYWORD: Final[List[str]] = [
     "Tags",
 ]
 
-RE_POSSIBLE_ENCODING_INDICATION: Final = re_compile(
+RE_POSSIBLE_ENCODING_INDICATION: Final[Pattern] = re_compile(
     r"(?:(?:encoding)|(?:charset)|(?:coding))(?:[\:= ]{1,10})(?:[\"\']?)([a-zA-Z0-9\-_]+)(?:[\"\']?)",
     IGNORECASE,
 )

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -4,7 +4,7 @@ from encodings.aliases import aliases
 from re import IGNORECASE, compile as re_compile
 from typing import Dict, List, Set, Union
 
-if sys.version_info <= (3, 8):
+if sys.version_info < (3, 8):
     from typing_extensions import Final
 else:
     from typing import Final

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ black==22.6.0
 flake8==5.0.4
 mypy==0.971
 isort
+typing_extensions


### PR DESCRIPTION
From [mypy docs](https://mypy.readthedocs.io/en/stable/final_attrs.html?highlight=Final):
`
You can use the typing.Final qualifier to indicate that a name or attribute should not be reassigned, redefined, or overridden. This is often useful for module and class level constants as a way to prevent unintended modification. Mypy will prevent further assignments to final names in type-checked code:
`

Testing after mypy compiling:
```python3
python3 setup.py --use-mypyc build_ext --inplace
```

Before commit:
```python3
------------------------------
--> Chardet Conclusions
   --> Avg: 0.1224901914893617s
   --> 99th: 0.73647s
   --> 95th: 0.17915s
   --> 50th: 0.01755s
------------------------------
--> Charset-Normalizer Conclusions
   --> Avg: 0.010322106382978723s
   --> 99th: 0.11215s
   --> 95th: 0.05355s
   --> 50th: 0.00428s
------------------------------
--> Charset-Normalizer / Chardet: Performance Сomparison
   --> Avg: x11.87
   --> 99th: x6.57
   --> 95th: x3.35
   --> 50th: x4.1
```
After commit:
```python3
------------------------------
--> Chardet Conclusions
   --> Avg: 0.12217872340425531s
   --> 99th: 0.72175s
   --> 95th: 0.17481s
   --> 50th: 0.01731s
------------------------------
--> Charset-Normalizer Conclusions
   --> Avg: 0.01016231914893617s
   --> 99th: 0.1085s
   --> 95th: 0.05219s
   --> 50th: 0.00419s
------------------------------
--> Charset-Normalizer / Chardet: Performance Сomparison
   --> Avg: x12.02
   --> 99th: x6.65
   --> 95th: x3.35
   --> 50th: x4.13
```