### PR TITLE
📝 Remove the nonexistent encoding tactis in docs which was removed officially in Python 3.9 (bpo-35551)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This project offers you an alternative to **Universal Charset Encoding Detector*
 | `Detect spoken language` | ❌ | :heavy_check_mark: | N/A |
 | `UnicodeDecodeError Safety` | ❌ | :heavy_check_mark: | ❌ |
 | `Whl Size` | 193.6 kB | 39.5 kB | ~200 kB |
-| `Supported Encoding` | 33 | :tada: [93](https://charset-normalizer.readthedocs.io/en/latest/user/support.html#supported-encodings)  | 40
+| `Supported Encoding` | 33 | :tada: [92](https://charset-normalizer.readthedocs.io/en/latest/user/support.html#supported-encodings)  | 40
 
 <p align="center">
 <img src="https://i.imgflip.com/373iay.gif" alt="Reading Normalized Text" width="226"/><img src="https://media.tenor.com/images/c0180f70732a18b4965448d33adba3d0/tenor.gif" alt="Cat Reading Text" width="200"/>

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -98,7 +98,6 @@ rot_13           rot13
 shift_jis        csshiftjis, shiftjis, sjis, s_jis, x_mac_japanese
 shift_jis_2004   shiftjis2004, sjis_2004, s_jis_2004
 shift_jisx0213   shiftjisx0213, sjisx0213, s_jisx0213
-tactis           tis260
 tis_620          tis620, tis_620_0, tis_620_2529_0, tis_620_2529_1, iso_ir_166
 utf_16           u16, utf16
 utf_16_be        unicodebigunmarked, utf_16be


### PR DESCRIPTION
The tactis/tis260 encoding does not exist in Python actually, so it is removed in Python 3.9 officially.

See [bpo-35551](https://github.com/python/cpython/issues/79732) for details.