### PR TITLE
Release 3.0.1

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev" ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10", "3.11" ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -222,8 +222,8 @@ jobs:
           CIBW_ENVIRONMENT: CHARSET_NORMALIZER_USE_MYPYC='1'
           CIBW_BEFORE_BUILD: pip install -r build-requirements.txt
           #CIBW_CONFIG_SETTINGS: "--build-option=--no-isolation"
-          CIBW_TEST_REQUIRES: pytest codecov pytest-cov
-          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest -c {package} {package}/tests
           CIBW_SKIP: pp*
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [3.0.1](https://github.com/Ousret/charset_normalizer/compare/3.0.0...master) (unreleased)
+## [3.0.1](https://github.com/Ousret/charset_normalizer/compare/3.0.0...3.0.1) (2022-11-18)
 
 ### Fixed
 - Multi-bytes cutter/chunk generator did not always cut correctly (PR #233)
+
+### Changed
+- Speedup provided by mypy/c 0.990 on Python >= 3.7
 
 ## [3.0.0](https://github.com/Ousret/charset_normalizer/compare/2.1.1...3.0.0) (2022-10-20)
 

--- a/charset_normalizer/version.py
+++ b/charset_normalizer/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "3.0.1-dev"
+__version__ = "3.0.1"
 VERSION = __version__.split(".")


### PR DESCRIPTION
## [3.0.1](https://github.com/Ousret/charset_normalizer/compare/3.0.0...3.0.1) (2022-11-18)

### Fixed
- Multi-bytes cutter/chunk generator did not always cut correctly (PR #233)

### Changed
- Speedup provided using mypy/c 0.990 on Python >= 3.7