### PR TITLE
Fix minor pytest deprecation

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,7 +7,7 @@ from charset_normalizer.constant import TRACE
 
 
 class TestLogBehaviorClass:
-    def setup(self):
+    def setup_method(self):
         self.logger = logging.getLogger("charset_normalizer")
         self.logger.handlers.clear()
         self.logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
```
/_pytest/fixtures.py:900: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  project/tests/test_logging.py::TestLogBehaviorClass::test_set_stream_handler_format is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
```
