### PR TITLE
GitHub Actions: ubuntu-latest no longer supports Python 3.6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]  # ubuntu-latest no longer supports Python 3.6
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/actions/setup-python/issues/544#issuecomment-1332535877

This failure is blocking other pull requests:
* https://github.com/Ousret/charset_normalizer/pulls

The alternative would be to drop Python 3.6 which is no longer supported:
* https://devguide.python.org/versions