### PR TITLE
:fire: Drop the support for EOL Python 3.6

### DIFF
--- a/.github/workflows/mypyc-verify.yml
+++ b/.github/workflows/mypyc-verify.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
         os: [ubuntu-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.1.0-dev0](https://github.com/Ousret/charset_normalizer/compare/3.0.1...master) (unreleased)
+
+### Removed
+- Support for Python 3.6 (PR #260)
+
 ## [3.0.1](https://github.com/Ousret/charset_normalizer/compare/3.0.0...3.0.1) (2022-11-18)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ that intel is worth something here. So I use those records against decoded text 
   - Language detection is unreliable when text contains two or more languages sharing identical letters. (eg. HTML (english tags) + Turkish content (Sharing Latin characters))
   - Every charset detector heavily depends on sufficient content. In common cases, do not bother run detection on very tiny content.
 
+## ⚠️ About Python EOLs
+
+**If you are running:**
+
+- Python >=2.7,<3.5: Unsupported
+- Python 3.5: charset-normalizer < 2.1
+- Python 3.6: charset-normalizer < 3.1
+
+Upgrade your Python interpreter as soon as possible.
+
 ## 👤 Contributing
 
 Contributions, issues and feature requests are very much welcome.<br />

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,6 +1,5 @@
 # in the meantime we migrate to pyproject.toml
 # this represent the minimum requirement to build (for the optional speedup)
-mypy==0.991; python_version >= "3.7"
-mypy==0.971; python_version < "3.7"
-build==0.9.0
-wheel==0.37.1
+mypy==0.991
+build==0.10.0
+wheel==0.38.4

--- a/charset_normalizer/version.py
+++ b/charset_normalizer/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "3.0.1"
+__version__ = "3.1.0-dev0"
 VERSION = __version__.split(".")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,24 +1,13 @@
 flake8==5.0.4
-chardet==5.0.0
-isort==5.10.1
+chardet==5.1.0
+isort==5.11.4
 codecov==2.1.12
 pytest-cov==4.0.0
-build==0.9.0
-wheel==0.37.1
+build==0.10.0
+wheel==0.38.4
 
-# The vast majority of project dropped Python 3.6
-# This is to ensure build are reproducible >=3.6
-black==22.8.0; python_version < "3.7"
-black==22.10.0; python_version >= "3.7"
-
-mypy==0.991; python_version >= "3.7"
-mypy==0.971; python_version < "3.7"
-
-Flask==2.2.2; python_version >= "3.7"
-Flask==2.0.3; python_version < "3.7"
-
-pytest==7.0.0; python_version < "3.7"
-pytest==7.2.0; python_version >= "3.7"
-
-requests==2.27.1; python_version < "3.7"
-requests==2.28.1; python_version >= "3.7"
+black==22.12.0
+mypy==0.991
+Flask==2.2.2
+pytest==7.2.1
+requests==2.28.2

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -2,12 +2,20 @@
  Support
 =================
 
-Here are a list of supported encoding and supported language with latest update. Also this list
-may change depending of your python version.
+**If you are running:**
+
+- Python >=2.7,<3.5: Unsupported
+- Python 3.5: charset-normalizer < 2.1
+- Python 3.6: charset-normalizer < 3.1
+
+Upgrade your Python interpreter as soon as possible.
 
 -------------------
 Supported Encodings
 -------------------
+
+Here are a list of supported encoding and supported language with latest update. Also this list
+may change depending of your python version.
 
 Charset Normalizer is able to detect any of those encoding. This list is NOT static and depends heavily on what your
 current cPython version is shipped with. See https://docs.python.org/3/library/codecs.html#standard-encodings

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/Ousret/charset_normalizer
 license = MIT
 author_email = ahmed.tahri@cloudnursery.dev
 author = Ahmed TAHRI
-python_requires = >=3.6.0
+python_requires = >=3.7.0
 project_urls =
     Bug Reports = https://github.com/Ousret/charset_normalizer/issues
     Documentation = https://charset-normalizer.readthedocs.io/en/latest
@@ -20,7 +20,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Starting off next release >=3.1.0