### PR TITLE
:sparkle: Add support for (nine) encoding that have no aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Allow to execute the CLI (e.g. normalizer) through `python -m charset_normalizer.cli`
+- Support for 9 forgotten encoding that are supported by Python but unlisted in `encoding.aliases` as they have no alias (#323)
 
 ## [3.2.0](https://github.com/Ousret/charset_normalizer/compare/3.1.0...3.2.0) (2023-06-07)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://img.shields.io/pypi/pyversions/charset_normalizer.svg?orange=blue" />
   </a>
   <a href="https://pepy.tech/project/charset-normalizer/">
-    <img alt="Download Count Total" src="https://pepy.tech/badge/charset-normalizer/month" />
+    <img alt="Download Count Total" src="https://static.pepy.tech/badge/charset-normalizer/month" />
   </a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/7297">
     <img src="https://bestpractices.coreinfrastructure.org/projects/7297/badge">
@@ -23,18 +23,18 @@
 
 This project offers you an alternative to **Universal Charset Encoding Detector**, also known as **Chardet**.
 
-| Feature                                          | [Chardet](https://github.com/chardet/chardet) |                                           Charset Normalizer                                           | [cChardet](https://github.com/PyYoshi/cChardet) |
-|--------------------------------------------------|:---------------------------------------------:|:------------------------------------------------------------------------------------------------------:|:-----------------------------------------------:|
-| `Fast`                                           |                     ❌<br>                     |                                                 ✅<br>                                                  |                     ✅ <br>                      |
-| `Universal**`                                    |                       ❌                       |                                                   ✅                                                    |                        ❌                        |
-| `Reliable` **without** distinguishable standards |                       ❌                       |                                                   ✅                                                    |                        ✅                        |
-| `Reliable` **with** distinguishable standards    |                       ✅                       |                                                   ✅                                                    |                        ✅                        |
-| `License`                                        |           LGPL-2.1<br>_restrictive_           |                                                  MIT                                                   |            MPL-1.1<br>_restrictive_             |
-| `Native Python`                                  |                       ✅                       |                                                   ✅                                                    |                        ❌                        |
-| `Detect spoken language`                         |                       ❌                       |                                                   ✅                                                    |                       N/A                       |
-| `UnicodeDecodeError Safety`                      |                       ❌                       |                                                   ✅                                                    |                        ❌                        |
-| `Whl Size`                                       |                   193.6 kB                    |                                                 40 kB                                                  |                     ~200 kB                     |
-| `Supported Encoding`                             |                      33                       | 🎉 [90](https://charset-normalizer.readthedocs.io/en/latest/user/support.html#supported-encodings) |                       40                        |
+| Feature                                          | [Chardet](https://github.com/chardet/chardet) |                                         Charset Normalizer                                         | [cChardet](https://github.com/PyYoshi/cChardet) |
+|--------------------------------------------------|:---------------------------------------------:|:--------------------------------------------------------------------------------------------------:|:-----------------------------------------------:|
+| `Fast`                                           |                       ❌                       |                                                 ✅                                                  |                        ✅                        |
+| `Universal**`                                    |                       ❌                       |                                                 ✅                                                  |                        ❌                        |
+| `Reliable` **without** distinguishable standards |                       ❌                       |                                                 ✅                                                  |                        ✅                        |
+| `Reliable` **with** distinguishable standards    |                       ✅                       |                                                 ✅                                                  |                        ✅                        |
+| `License`                                        |           LGPL-2.1<br>_restrictive_           |                                                MIT                                                 |            MPL-1.1<br>_restrictive_             |
+| `Native Python`                                  |                       ✅                       |                                                 ✅                                                  |                        ❌                        |
+| `Detect spoken language`                         |                       ❌                       |                                                 ✅                                                  |                       N/A                       |
+| `UnicodeDecodeError Safety`                      |                       ❌                       |                                                 ✅                                                  |                        ❌                        |
+| `Whl Size (min)`                                 |                   193.6 kB                    |                                               42 kB                                                |                     ~200 kB                     |
+| `Supported Encoding`                             |                      33                       | 🎉 [99](https://charset-normalizer.readthedocs.io/en/latest/user/support.html#supported-encodings) |                       40                        |
 
 <p align="center">
 <img src="https://i.imgflip.com/373iay.gif" alt="Reading Normalized Text" width="226"/><img src="https://media.tenor.com/images/c0180f70732a18b4965448d33adba3d0/tenor.gif" alt="Cat Reading Text" width="200"/>
@@ -208,6 +208,7 @@ that intel is worth something here. So I use those records against decoded text 
 - Python >=2.7,<3.5: Unsupported
 - Python 3.5: charset-normalizer < 2.1
 - Python 3.6: charset-normalizer < 3.1
+- Python 3.7: charset-normalizer < 4.0
 
 Upgrade your Python interpreter as soon as possible.
 

--- a/bin/bc.py
+++ b/bin/bc.py
@@ -64,7 +64,7 @@ def cli_bc(arguments: List[str]):
             print("✅✅ '{}' (BC)".format(tbt_path))
             continue
 
-        if (chardet_encoding is None and charset_normalizer_encoding is None) or (iana_name(chardet_encoding) == iana_name(charset_normalizer_encoding)):
+        if (chardet_encoding is None and charset_normalizer_encoding is None) or (iana_name(chardet_encoding, False) == iana_name(charset_normalizer_encoding, False)):
             success_count += 1
             print("✅✅ '{}' (BC)".format(tbt_path))
             continue

--- a/charset_normalizer/constant.py
+++ b/charset_normalizer/constant.py
@@ -331,11 +331,23 @@ RE_POSSIBLE_ENCODING_INDICATION = re_compile(
     IGNORECASE,
 )
 
+IANA_NO_ALIASES = [
+    "cp720",
+    "cp737",
+    "cp856",
+    "cp874",
+    "cp875",
+    "cp1006",
+    "koi8_r",
+    "koi8_t",
+    "koi8_u",
+]
+
 IANA_SUPPORTED: List[str] = sorted(
     filter(
         lambda x: x.endswith("_codec") is False
         and x not in {"rot_13", "tactis", "mbcs"},
-        list(set(aliases.values())),
+        list(set(aliases.values())) + IANA_NO_ALIASES,
     )
 )
 

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -112,7 +112,16 @@ utf_32           u32, utf32
 utf_32_be        utf_32be
 utf_32_le        utf_32le
 utf_8            u8, utf, utf8, utf8_ucs2, utf8_ucs4 (+utf_8_sig)
-utf_7*            u7, unicode-1-1-utf-7
+utf_7*           u7, unicode-1-1-utf-7
+cp720            N.A.
+cp737            N.A.
+cp856            N.A.
+cp874            N.A.
+cp875            N.A.
+cp1006           N.A.
+koi8_r           N.A.
+koi8_t           N.A.
+koi8_u           N.A.
 ===============  ===============================================================================================================================
 
 *: Only if a SIG/mark is found.


### PR DESCRIPTION
Close #323 

List of added references:

```python
IANA_NO_ALIASES = [
    "cp720",
    "cp737",
    "cp856",
    "cp874",
    "cp875",
    "cp1006",
    "koi8_r",
    "koi8_t",
    "koi8_u",
]
```