### PR TITLE
Add a pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "charset-normalizer"
+dynamic = ["version", "description", "authors", "license", "readme", "urls", "classifiers", "requires-python", "keywords"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This allows building the project into a wheel with:
```
python -m build --wheel --no-isolation
```

Instead of the [deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary):
```
./setup.py build
```