### PR TITLE
use TypedDict for return type of legacy detect()

### DIFF
--- a/charset_normalizer/legacy.py
+++ b/charset_normalizer/legacy.py
@@ -1,21 +1,19 @@
-import sys
-from typing import Any, Dict, Optional, Union
+from __future__ import annotations
+from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 from warnings import warn
 
 from .api import from_bytes
 from .constant import CHARDET_CORRESPONDENCE
 
 # TODO: remove this check when dropping Python 3.7 support
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
+if TYPE_CHECKING:
+    from typing_extensions import TypedDict
 
     class ResultDict(TypedDict):
         encoding: Optional[str]
         language: str
         confidence: Optional[float]
 
-else:
-    ResultDict = Dict[str, Optional[Union[str, float]]]
 
 
 def detect(

--- a/charset_normalizer/legacy.py
+++ b/charset_normalizer/legacy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import Any, Dict, Optional, Union, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Any, Optional
 from warnings import warn
 
 from .api import from_bytes
@@ -13,7 +14,6 @@ if TYPE_CHECKING:
         encoding: Optional[str]
         language: str
         confidence: Optional[float]
-
 
 
 def detect(

--- a/charset_normalizer/legacy.py
+++ b/charset_normalizer/legacy.py
@@ -1,13 +1,26 @@
+import sys
 from typing import Any, Dict, Optional, Union
 from warnings import warn
 
 from .api import from_bytes
 from .constant import CHARDET_CORRESPONDENCE
 
+# TODO: remove this check when dropping Python 3.7 support
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+
+    class ResultDict(TypedDict):
+        encoding: Optional[str]
+        language: str
+        confidence: Optional[float]
+
+else:
+    ResultDict = Dict[str, Optional[Union[str, float]]]
+
 
 def detect(
     byte_str: bytes, should_rename_legacy: bool = False, **kwargs: Any
-) -> Dict[str, Optional[Union[str, float]]]:
+) -> ResultDict:
     """
     chardet legacy method
     Detect the encoding of the given byte string. It should be mostly backward-compatible.


### PR DESCRIPTION
### Problem to solve

when I write something like:
```python3
x = charset_normalizer.detect(...)["encoding"]
```

`x` is inferred as `str | float | None` instead of actual `str | None`.

### Change

use custom `TypedDict` type as the return type of `detect` method if Python version >= 3.8.
(`TypedDict` is not available in Python 3.7)