### PR TITLE
Update performance script to test multithreading

### DIFF
--- a/bin/performance.py
+++ b/bin/performance.py
@@ -239,7 +239,9 @@ def analyse(file_list, charset_normalizer_results, chardet_results, num_threads=
     stdev_time = stdev(charset_normalizer_results)
     mean_time = mean(charset_normalizer_results)
     cv = (stdev_time / mean_time) * 100  # Coefficient of variation
-    print(f"\n{'-' * 102}\nCharset Normalizer statistics (using {num_threads} thread(s)):\n")
+    print(
+        f"\n{'-' * 102}\nCharset Normalizer statistics (using {num_threads} thread(s)):\n"
+    )
     print(f"Minimum Execution Time: {min_time:.5f} seconds")
     print(f"Maximum Execution Time: {max_time:.5f} seconds")
     print(f"Mean Execution Time: {mean_time:.5f} seconds")

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,18 @@ def test_impl(
 
 
 @nox.session(
-    python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy"]
+    python=[
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+        "3.14t",
+        "pypy",
+    ]
 )
 def test(session: nox.Session) -> None:
     test_impl(session)


### PR DESCRIPTION
Nox:

- Add 3.14t targets to noxfile (this needs the current Python to be 3.14t AFAICT)

- `--no-rebuild` flag to nox, for when one want to rapidely run multiple sessions with different number of threads

performace.py

- add and `--export` flag to export raw result as CSV mostly if one want to compare timeing across multiple number of threads.

- add a --quiet flag to no print individual results, works well with export.

- add -n option to run with 0 (in main threads), or 1+ Threads in a threadpool executor. This refactor a bit the measurement, and in particular we load the files twice, once for chardet and once for charset_normalizer. I could load once, and store, but that woudl blow up memory. Also adds a few more timing to see the potential "speedup", show munber of thread, and wall time.  I also try to submit N=nthreads batch of files, but it does not change the end result much.

Roughtly testing on free-threaded give the same result as gil-enabled python:

    Total CN detection time:  10.77s  # roughly wall-time x Nthreads.
    Total CN Wall      time:  5.45s

This should help with the comment on #616,
locally on macos 15.6.1 everythong works (test, perf, integration), with the exception of brotlicffi, and perf on multi-threaded that is worse than single threaded.