### PR TITLE
Fix logger level not restored correctly for empty byte sequences

### DIFF
--- a/src/charset_normalizer/api.py
+++ b/src/charset_normalizer/api.py
@@ -78,7 +78,7 @@ def from_bytes(
         logger.debug("Encoding detection on empty bytes, assuming utf_8 intention.")
         if explain:  # Defensive: ensure exit path clean handler
             logger.removeHandler(explain_handler)
-            logger.setLevel(previous_logger_level or logging.WARNING)
+            logger.setLevel(previous_logger_level)
         return CharsetMatches([CharsetMatch(sequences, "utf_8", 0.0, False, [], "")])
 
     if cp_isolation is not None:


### PR DESCRIPTION
## Summary

Fix incorrect logger level restoration after `from_bytes(b"", explain=True)`.

## Problem

When `from_bytes()` is called with `explain=True` on an empty byte sequence, the early-return path restores the logger level with:

```python
logger.setLevel(previous_logger_level or logging.WARNING)
```

The default logger level is `NOTSET` (integer `0`). Because `0` is falsy, the `or` expression evaluates to `logging.WARNING` (`30`) instead of `0`:

```python
>>> 0 or logging.WARNING
30
```

This permanently changes the `charset_normalizer` logger from `NOTSET` to `WARNING`. The effect: any user-configured handler expecting `DEBUG` or `INFO` messages from the library will silently stop receiving them after a single `from_bytes(b"", explain=True)` call.

All *other* exit paths in the same function correctly restore the level without the `or` fallback:

```python
logger.setLevel(previous_logger_level)  # correct (lines 468, 486, 498, 540)
```

Only the empty-sequence path at line 81 had the bug.

## Fix

Remove the `or logging.WARNING` fallback so it behaves the same as every other exit path.
