### PR TITLE
Fix --normalize writing to wrong path with multiple files

### DIFF
--- a/src/charset_normalizer/cli/__main__.py
+++ b/src/charset_normalizer/cli/__main__.py
@@ -341,9 +341,9 @@ def cli_detect(argv: list[str] | None = None) -> int:
                     continue
 
                 try:
-                    x_[0].unicode_path = join(dir_path, ".".join(o_))
+                    x_[-1].unicode_path = join(dir_path, ".".join(o_))
 
-                    with open(x_[0].unicode_path, "wb") as fp:
+                    with open(x_[-1].unicode_path, "wb") as fp:
                         fp.write(best_guess.output())
                 except OSError as e:
                     print(str(e), file=sys.stderr)


### PR DESCRIPTION
## Summary

Fix incorrect file index when writing normalized output for multiple files.

## Problem

When normalizing multiple files with `normalizer --normalize file1.txt file2.txt`, the CLI always references `x_[0]` (the first result entry) instead of the current file's result:

```python
x_[0].unicode_path = join(dir_path, ".".join(o_))

with open(x_[0].unicode_path, "wb") as fp:
    fp.write(best_guess.output())
```

For the second file onward, this:
1. Overwrites the first entry's `unicode_path` with the current file's output path
2. Writes the normalized content to a path derived from the wrong entry

## Fix

Use `x_[-1]` to reference the most recently appended result, which is always the current file being processed.
