### PR TITLE
fix TypeError when passing bytearray to from_bytes

### DIFF
--- a/src/charset_normalizer/utils.py
+++ b/src/charset_normalizer/utils.py
@@ -226,7 +226,7 @@ def any_specified_encoding(sequence: bytes, search_zone: int = 8192) -> str | No
     """
     Extract using ASCII-only decoder any specified encoding in the first n-bytes.
     """
-    if not isinstance(sequence, bytes):
+    if not isinstance(sequence, (bytes, bytearray)):
         raise TypeError
 
     seq_len: int = len(sequence)


### PR DESCRIPTION
This PR fixes a bug where passing a valid `bytearray` to `from_bytes` crashes the application with a `TypeError`. The `api.from_bytes` type hints explicitly support `bytearray`, but the underlying helper function `utils.any_specified_encoding` did not.

**What actually happens:**
When `from_bytes` is called with a `bytearray` and `preemptive_behaviour=True`, `utils.any_specified_encoding` raises a `TypeError` because it strictly checks `if not isinstance(sequence, bytes):`.

**What I expected to happen:**
The function should successfully process the `bytearray` sequence and return a `CharsetMatches` object, just as it does for standard `bytes` objects.

**How to reproduce the issue:**

```python
from charset_normalizer import from_bytes

# Create a bytearray object 
my_bytearray = bytearray(b"Hello, world!")

# This will raise a TypeError on the current main branch
results = from_bytes(my_bytearray)

```

**Changes Made:**

* Updated `utils.py` around line 260 to check for `isinstance(sequence, (bytes, bytearray))` instead of strictly `bytes`.
* This fix ensures backward compatibility while aligning the runtime behavior with the documented type hints.

**Checklist:**

* [x] I have read the `CONTRIBUTING.md` document.
* [x] I have verified that this does not break backward compatibility.
* [x] I have successfully run `nox -s test` locally.
* [x] I have successfully run `nox -s lint` locally.
* [x] I have successfully run `nox -s coverage` locally.