### PR TITLE
correct cp_similarity ratio ceiling

### DIFF
--- a/src/charset_normalizer/utils.py
+++ b/src/charset_normalizer/utils.py
@@ -326,12 +326,12 @@ def cp_similarity(iana_name_a: str, iana_name_b: str) -> float:
 
     character_match_count: int = 0
 
-    for i in range(255):
+    for i in range(256):
         to_be_decoded: bytes = bytes([i])
         if id_a.decode(to_be_decoded) == id_b.decode(to_be_decoded):
             character_match_count += 1
 
-    return character_match_count / 254
+    return character_match_count / 256
 
 
 def is_cp_similar(iana_name_a: str, iana_name_b: str) -> bool:


### PR DESCRIPTION
* **The Issue:** `utils.cp_similarity` calculates the similarity between two code pages by decoding all possible single-byte sequences. However, the loop used `range(255)` (which skips the final byte, `0xFF`) and divided the result by `254`. If two encodings were exactly the same, this resulted in a similarity ratio of `~1.0039` instead of a maximum of `1.0`.
* **The Fix:** Updated the iteration to `range(256)` and the return calculation to `character_match_count / 256`.

## Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have ensured that these changes do not break backward compatibility.
- [x] I have run the mandatory local checks successfully using `nox` (`nox -s test`, `nox -s lint`, and `nox -s coverage`).