### PR TITLE
Remove redundant UTF7 BOM

### DIFF
--- a/src/charset_normalizer/constant.py
+++ b/src/charset_normalizer/constant.py
@@ -9,7 +9,6 @@ from re import compile as re_compile
 ENCODING_MARKS: dict[str, bytes | list[bytes]] = {
     "utf_8": BOM_UTF8,
     "utf_7": [
-        b"\x2b\x2f\x76\x38\x2d",
         b"\x2b\x2f\x76\x38",
         b"\x2b\x2f\x76\x39",
         b"\x2b\x2f\x76\x2b",


### PR DESCRIPTION
One of the UTF7 byte order mark (BOM) variants was redundant; it is an extension of one of the subsequent pattern variants.

This does not affect correctness, but it does imply that string-matching work may be duplicated.

Remove the longer, superset prefix to remove a comparison when inspecting some UTF7 BOM content.

Refs:
 - Closes #716.
 - Follow-up to PR #717.
 - Relates-to commit b579cd6cab9bd83aa3fc0ca169d4df022bf4888c.