### PR TITLE
Late-import json

### DIFF
--- a/src/charset_normalizer/cli/__main__.py
+++ b/src/charset_normalizer/cli/__main__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import sys
 import typing
-from json import dumps
 from os.path import abspath, basename, dirname, join, realpath
 from platform import python_version
 from unicodedata import unidata_version
@@ -336,6 +335,8 @@ def cli_detect(argv: list[str] | None = None) -> int:
             my_file.close()
 
     if args.minimal is False:
+        from json import dumps
+
         print(
             dumps(
                 [el.__dict__ for el in x_] if len(x_) > 1 else x_[0].__dict__,

--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from encodings.aliases import aliases
-from json import dumps
 from re import sub
 from typing import Any, Iterator, List, Tuple
 
@@ -366,4 +365,6 @@ class CliDetectionResult:
         }
 
     def to_json(self) -> str:
+        from json import dumps
+
         return dumps(self.__dict__, ensure_ascii=True, indent=4)


### PR DESCRIPTION
`json` is only needed for diagnostic use in `charset_normalizer`, so importing it unconditionally is unnecessary.

Sibling of #752 - without #752, importing all of the `encodings`es makes this disappear in measurement noise, but stacked on #752, this shaves another 3% off for apps that don't necessarily need `json` for anything...

```
hyperfine --warmup=5 'git checkout really-precompute && python -c "import charset_normalizer"' 'git checkout really-precompute-and-lazy-json && python -c "import charset_normalizer"'
Benchmark 1: git checkout really-precompute && python -c "import charset_normalizer"
  Time (mean ± σ):      43.5 ms ±   0.8 ms    [User: 32.0 ms, System: 10.3 ms]
  Range (min … max):    42.1 ms …  45.6 ms    65 runs

Benchmark 2: git checkout really-precompute-and-lazy-json && python -c "import charset_normalizer"
  Time (mean ± σ):      42.4 ms ±   0.9 ms    [User: 31.2 ms, System: 10.0 ms]
  Range (min … max):    40.8 ms …  44.8 ms    65 runs

Summary
  git checkout really-precompute-and-lazy-json && python -c "import charset_normalizer" ran
    1.03 ± 0.03 times faster than git checkout really-precompute && python -c "import charset_normalizer"
```