### PR TITLE
docs: remove dead "Try Me Online" demo link (#751)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@
 > All IANA character set names for which the Python core library provides codecs are supported.
 > You can also register your own set of codecs, and yes, it would work as-is.
 
-<p align="center">
-  >>>>> <a href="https://charsetnormalizerweb.ousret.now.sh" target="_blank">👉 Try Me Online Now, Then Adopt Me 👈 </a> <<<<<
-</p>
-
 This project offers you an alternative to **Universal Charset Encoding Detector**, also known as **Chardet**.
 
 | Feature                                          | [Chardet](https://github.com/chardet/chardet) |                                       Charset Normalizer                                        | [cChardet](https://github.com/PyYoshi/cChardet) |


### PR DESCRIPTION
## Summary

Closes #751.

The "Try Me Online Now, Then Adopt Me" banner in the README links to `https://charsetnormalizerweb.ousret.now.sh`, which is no longer reachable (the `now.sh` host has been retired). Readers who click it land on a dead page.

This removes the broken promo block. If the demo is later re-hosted, the banner can be re-added pointing at the new URL.