### PR TITLE
fix: make CharsetMatch.__eq__ total for non-alias strings

### DIFF
--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -40,7 +40,11 @@ class CharsetMatch:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CharsetMatch):
             if isinstance(other, str):
-                return iana_name(other) == self.encoding
+                # Use non-strict iana_name so an operand that is not a known
+                # encoding alias compares unequal instead of raising, keeping
+                # __eq__ total as the data model requires (mirrors the lookup
+                # in CharsetMatches.__getitem__).
+                return iana_name(other, False) == self.encoding
             return False
         return self.encoding == other.encoding and self.fingerprint == other.fingerprint
 

--- a/tests/test_base_detection.py
+++ b/tests/test_base_detection.py
@@ -210,3 +210,23 @@ def test_direct_cmp_charset_match():
     assert best_guess == "utf-8"
     assert best_guess != 8
     assert best_guess != None
+
+
+def test_match_equality_with_arbitrary_string():
+    """CharsetMatch.__eq__ must be total: comparing to a string that is not a
+    known encoding alias returns False, it does not raise (data-model /
+    membership contract)."""
+    best_guess = from_bytes(b"Hello world plain ascii text here.").best()
+    assert best_guess is not None
+
+    # Valid encoding aliases still compare as before.
+    assert best_guess == best_guess.encoding
+    assert (best_guess == "utf-16") is False
+
+    # Arbitrary strings (not codec aliases) must compare unequal, not raise.
+    assert (best_guess == "not-a-real-encoding") is False
+    assert (best_guess == "hello") is False
+    assert (best_guess == 123) is False
+
+    # Membership relies on __eq__, so this must not raise either.
+    assert "not-a-real-encoding" not in [best_guess]


### PR DESCRIPTION
`CharsetMatch.__eq__` compares a match to a string via `iana_name(other)` with the default `strict=True`, so any operand that isn't a known encoding alias raises `ValueError` instead of returning `False`:

```python
m = from_bytes(b"Hello world plain ascii text here.").best()
m == "ascii"                # True
m == "utf-8"                # False
m == "not-a-real-encoding"  # -> ValueError: Unable to retrieve IANA for 'not_a_real_encoding'
"hello" in [m]              # -> ValueError (membership uses __eq__)
```

That breaks `match == label` / `label in matches` for arbitrary strings and violates the data model, which requires `__eq__` to return a value for any operand (never raise). The fix uses non-strict `iana_name`, mirroring the tolerant lookup already in `CharsetMatches.__getitem__` (which does `iana_name(item, False)`). Valid aliases compare exactly as before; unknown strings now compare unequal.

Added a regression test; full suite stays green (164 passed). Happy to add a CHANGELOG entry if you curate those manually.

*Found, fixed, and tested by an AI coding agent (Claude Code) running autonomously on this account; the human account holder reviews every change and is accountable for it. The repro and test are real and re-runnable from it — just say the word if this isn't a contribution you want.*

