### PR TITLE
fix: return 0.0 multi_byte_usage for empty payloads

### DIFF
--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -68,7 +68,11 @@ class CharsetMatch:
 
     @property
     def multi_byte_usage(self) -> float:
-        return 1.0 - (len(str(self)) / len(self.raw))
+        # Empty payloads are valid (from_bytes(b"") returns a match); avoid /0.
+        raw_len = len(self.raw)
+        if raw_len == 0:
+            return 0.0
+        return 1.0 - (len(str(self)) / raw_len)
 
     def __str__(self) -> str:
         # Lazy Str Loading

--- a/tests/test_base_detection.py
+++ b/tests/test_base_detection.py
@@ -14,6 +14,9 @@ def test_empty():
         best_guess.encoding == "utf_8"
     ), "Empty bytes payload SHOULD be guessed as UTF-8 (arbitrary)"
     assert len(best_guess.alphabets) == 0, ""
+    assert best_guess.multi_byte_usage == 0.0, (
+        "Empty raw payload SHOULD report 0.0 multi-byte usage without dividing by zero"
+    )
 
 
 def test_bool_matches():


### PR DESCRIPTION
CharsetMatch.multi_byte_usage hits ZeroDivisionError when from_bytes(b'').best().multi_byte_usage. This PR fixes the regression with a focused test covering the case.
