### PR TITLE
fix: reject non-positive steps in from_bytes

### DIFF
--- a/src/charset_normalizer/api.py
+++ b/src/charset_normalizer/api.py
@@ -84,6 +84,9 @@ def from_bytes(
             )
         )
 
+    if steps < 1:
+        raise ValueError("steps must be a positive integer")
+
     if explain:
         previous_logger_level: int = logger.level
         logger.addHandler(explain_handler)

--- a/tests/test_edge_case.py
+++ b/tests/test_edge_case.py
@@ -72,3 +72,11 @@ def test_regression_gh771_fallback_entry_on_undecodable_payload():
         f"expected the utf_8 fallback, got {best_guess.encoding}"
     )
     assert str(best_guess), "best match must decode without error"
+
+
+def test_from_bytes_rejects_non_positive_steps():
+    with pytest.raises(ValueError, match="steps must be a positive integer"):
+        from_bytes(b"hello world", steps=0)
+    with pytest.raises(ValueError, match="steps must be a positive integer"):
+        from_bytes(b"hello world", steps=-1)
+    assert from_bytes(b"hello world", steps=1).best() is not None


### PR DESCRIPTION
from_bytes hits ZeroDivisionError when steps=0 divides length by zero. This PR fixes the regression with a focused test covering the case.
