### PR TITLE
Raise KeyError, not IndexError, on out-of-range CharsetMatches index

### DIFF
--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -276,7 +276,12 @@ class CharsetMatches:
         Raise KeyError upon invalid index or encoding not present in results.
         """
         if isinstance(item, int):
-            return self._results[item]
+            try:
+                return self._results[item]
+            except IndexError:
+                # Honor the documented contract (and match the string path
+                # below): an invalid position raises KeyError, not IndexError.
+                raise KeyError(item)
         if isinstance(item, str):
             item = iana_name(item, False)
             for result in self._results:

--- a/tests/test_base_detection.py
+++ b/tests/test_base_detection.py
@@ -233,3 +233,26 @@ def test_match_equality_with_arbitrary_string():
 
     # Membership relies on __eq__, so this must not raise either.
     assert "not-a-real-encoding" not in [best_guess]
+
+
+def test_getitem_invalid_index_raises_keyerror():
+    """CharsetMatches.__getitem__ documents 'Raise KeyError upon invalid
+    index'. An out-of-range integer position must raise KeyError, matching the
+    string-lookup path, not IndexError."""
+    matches = from_bytes(b"Hello world plain ascii text here.")
+    assert len(matches) >= 1
+
+    # A valid position still works.
+    assert matches[0] is matches.best()
+
+    # Out-of-range positions raise KeyError, not IndexError.
+    with pytest.raises(KeyError):
+        matches[len(matches)]
+    with pytest.raises(KeyError):
+        matches[10_000]
+    with pytest.raises(KeyError):
+        matches[-10_000]
+
+    # Empty container: any position is invalid -> KeyError.
+    with pytest.raises(KeyError):
+        CharsetMatches([])[0]


### PR DESCRIPTION
## Summary

`CharsetMatches.__getitem__` is documented to raise `KeyError` on an invalid
index:

> Retrieve a single item either by its position or encoding name... **Raise
> KeyError upon invalid index** or encoding not present in results.

The string-lookup path already does. But the integer path uses plain list
indexing, so an out-of-range position raises `IndexError` instead:

```python
>>> from charset_normalizer import from_bytes
>>> m = from_bytes(b"hello world plain ascii")
>>> m[100]
IndexError: list index out of range      # docstring + string path say KeyError
>>> m["no_such_encoding"]
KeyError: 'no_such_encoding'              # string path is already correct
```

This finishes #52 (*"Fix undesired exception (ValueError) on getitem of instance
CharsetMatches"*), which fixed the same contract for the **string** path and
left the **integer** path raising `IndexError`.

## Fix

Wrap the integer lookup to raise `KeyError` on `IndexError`, so both subscript
forms honor the documented contract. Valid indices are unchanged; `best()` /
`first()` index `self._results` directly and are unaffected.

Added a regression test (`test_getitem_invalid_index_raises_keyerror`) covering
out-of-range positive/negative indices and an empty `CharsetMatches`. Full test
suite: **165 passed**.

## Expected vs actual

- **Expected:** `matches[<out-of-range int>]` raises `KeyError` (as documented,
  and as the string path already does).
- **Actual (before):** it raises `IndexError`.

---

Disclosure: this PR was authored by an AI coding agent (Claude Code) running on
this account — it found the mismatch against the docstring, reproduced it, wrote
the fix and the test, and wrote this description. The account holder reviews
every change and is accountable for it, and the verification above is real and
re-runnable from the diff. Happy to close it if it isn't the kind of
contribution you want.
