### PR TITLE
fix: map utf_8_sig to utf-8 for charset declaration rewrite

### DIFF
--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -234,11 +234,17 @@ class CharsetMatch:
                 and self._preemptive_declaration.lower()
                 not in ["utf-8", "utf8", "utf_8"]
             ):
+                # utf_8_sig is not in encodings.aliases; meta/XML charset is still utf-8.
+                declaration_encoding = (
+                    "utf_8"
+                    if encoding.replace("-", "_").lower() == "utf_8_sig"
+                    else encoding
+                )
                 patched_header = sub(
                     RE_POSSIBLE_ENCODING_INDICATION,
                     lambda m: m.string[m.span()[0] : m.span()[1]].replace(
                         m.groups()[0],
-                        iana_name(self._output_encoding).replace("_", "-"),  # type: ignore[arg-type]
+                        iana_name(declaration_encoding).replace("_", "-"),  # type: ignore[arg-type]
                     ),
                     decoded_string[:8192],
                     count=1,

--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -234,7 +234,6 @@ class CharsetMatch:
                 and self._preemptive_declaration.lower()
                 not in ["utf-8", "utf8", "utf_8"]
             ):
-                # utf_8_sig is not in encodings.aliases; meta/XML charset is still utf-8.
                 declaration_encoding = (
                     "utf_8"
                     if encoding.replace("-", "_").lower() == "utf_8_sig"

--- a/tests/test_preemptive_detection.py
+++ b/tests/test_preemptive_detection.py
@@ -90,3 +90,24 @@ def test_preemptive_mark_replacement(payload, expected_outcome):
     transformed_output = m.output()
 
     assert transformed_output == expected_outcome
+
+
+def test_output_utf_8_sig_rewrites_charset_declaration():
+    """utf_8_sig is a valid encode target but not an IANA alias; rewrite as utf-8."""
+    payload = (
+        b'<html><head><meta charset="windows-1252"></head><body>caf\xe9</body></html>'
+    )
+    m = CharsetMatch(
+        payload,
+        "cp1252",
+        0.0,
+        False,
+        [],
+        preemptive_declaration="cp1252",
+    )
+
+    out = m.output("utf_8_sig")
+
+    assert out.startswith(b"\xef\xbb\xbf")
+    assert b'charset="utf-8"' in out
+    assert b"caf\xc3\xa9" in out


### PR DESCRIPTION
CharsetMatch.output("utf_8_sig") raised ValueError when rewriting a non-UTF charset declaration, because utf_8_sig is not in encodings.aliases.

Use utf-8 for the declaration rewrite while still encoding the payload as utf_8_sig (BOM preserved).