### PR TITLE
fix: skip --normalize file write for stdin input

### DIFF
--- a/src/charset_normalizer/cli/__main__.py
+++ b/src/charset_normalizer/cli/__main__.py
@@ -286,6 +286,15 @@ def cli_detect(argv: list[str] | None = None) -> int:
                         )
 
             if args.normalize is True:
+                if my_file.name == "<stdin>":
+                    print(
+                        "Skipping normalize write for stdin input.",
+                        file=sys.stderr,
+                    )
+                    if my_file.closed is False:
+                        my_file.close()
+                    continue
+
                 if best_guess.encoding.startswith("utf") is True:
                     print(
                         '"{}" file does not need to be normalized, as it already came from unicode.'.format(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -184,6 +184,38 @@ class TestCommandLineInterface(unittest.TestCase):
             cli_detect([DIR_PATH + "/data/sample-arabic-1.txt", "--force"]), 1
         )
 
+    def test_normalize_stdin_skips_write(self):
+        """stdin + --normalize must not create a CWD file named like *.<stdin>."""
+        import io
+        import os
+        import tempfile
+        from contextlib import redirect_stderr, redirect_stdout
+
+        arabic_path = DIR_PATH + "/data/sample-arabic-1.txt"
+        with open(arabic_path, "rb") as fp:
+            payload = fp.read()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            try:
+                os.chdir(tmp)
+                stdin = io.BytesIO(payload)
+                stdin.name = "<stdin>"
+                with patch(
+                    "charset_normalizer.cli.__main__.FileType.__call__",
+                    return_value=stdin,
+                ):
+                    err = io.StringIO()
+                    out = io.StringIO()
+                    with redirect_stdout(out), redirect_stderr(err):
+                        code = cli_detect(["-", "--normalize"])
+            finally:
+                os.chdir(cwd)
+
+            self.assertEqual(code, 0)
+            self.assertIn("Skipping normalize write for stdin input", err.getvalue())
+            self.assertEqual(os.listdir(tmp), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
normalizer - --normalize treated stdin as a path named <stdin> and wrote a sibling file in the current directory (for example cp1256.<stdin>).

Skip the normalize write for stdin and print a short message on stderr instead.