### PR TITLE
fix: only rewrite matching charset declarations in output

### DIFF
--- a/src/charset_normalizer/constant.py
+++ b/src/charset_normalizer/constant.py
@@ -395,7 +395,7 @@ UNICODE_SECONDARY_RANGE_KEYWORD: list[str] = [
 ]
 
 RE_POSSIBLE_ENCODING_INDICATION = re_compile(
-    r"(?:(?:encoding)|(?:charset)|(?:coding))(?:[\:= ]{1,10})(?:[\"\']?)([a-zA-Z0-9\-_]+)(?:[\"\']?)",
+    r"(?:(?:encoding)|(?:charset)|(?:coding))(?:\s*[\:=]\s*)(?:[\"\']?)([a-zA-Z0-9\-_]+)(?:[\"\']?)",
     IGNORECASE,
 )
 

--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from encodings.aliases import aliases
-from re import sub
+from re import Match, sub
 from typing import Any, Iterator, List, Tuple
 
 from .constant import RE_POSSIBLE_ENCODING_INDICATION, TOO_BIG_SEQUENCE
@@ -234,14 +234,19 @@ class CharsetMatch:
                 and self._preemptive_declaration.lower()
                 not in ["utf-8", "utf8", "utf_8"]
             ):
+                declared = iana_name(self._preemptive_declaration, False)
+                replacement = iana_name(self._output_encoding).replace("_", "-")  # type: ignore[arg-type]
+
+                def rewrite_declaration(match: Match[str]) -> str:
+                    captured = match.groups()[0]
+                    if iana_name(captured, False) != declared:
+                        return match.group(0)
+                    return match.group(0).replace(captured, replacement)
+
                 patched_header = sub(
                     RE_POSSIBLE_ENCODING_INDICATION,
-                    lambda m: m.string[m.span()[0] : m.span()[1]].replace(
-                        m.groups()[0],
-                        iana_name(self._output_encoding).replace("_", "-"),  # type: ignore[arg-type]
-                    ),
+                    rewrite_declaration,
                     decoded_string[:8192],
-                    count=1,
                 )
 
                 decoded_string = patched_header + decoded_string[8192:]

--- a/src/charset_normalizer/models.py
+++ b/src/charset_normalizer/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from encodings.aliases import aliases
-from re import Match, sub
+from re import sub
 from typing import Any, Iterator, List, Tuple
 
 from .constant import RE_POSSIBLE_ENCODING_INDICATION, TOO_BIG_SEQUENCE
@@ -237,7 +237,7 @@ class CharsetMatch:
                 declared = iana_name(self._preemptive_declaration, False)
                 replacement = iana_name(self._output_encoding).replace("_", "-")  # type: ignore[arg-type]
 
-                def rewrite_declaration(match: Match[str]) -> str:
+                def rewrite_declaration(match: Any) -> str:
                     captured = match.groups()[0]
                     if iana_name(captured, False) != declared:
                         return match.group(0)

--- a/tests/test_preemptive_detection.py
+++ b/tests/test_preemptive_detection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from charset_normalizer import CharsetMatch
+from charset_normalizer import CharsetMatch, from_bytes
 from charset_normalizer.utils import any_specified_encoding
 
 
@@ -90,3 +90,33 @@ def test_preemptive_mark_replacement(payload, expected_outcome):
     transformed_output = m.output()
 
     assert transformed_output == expected_outcome
+
+
+def test_output_preserves_encoding_of_prose_near_charset_declaration():
+    """Prose like 'encoding of' must not be rewritten; only the real declaration."""
+    payload = (
+        b"The encoding of this file matters.\n"
+        b'<meta charset="windows-1252">\n'
+        b"Price: caf\xe9\n"
+    )
+    m = from_bytes(payload).best()
+    assert m is not None
+    out = m.output()
+    assert b"The encoding of this file matters." in out
+    assert b"The encoding utf-8 this" not in out
+    assert b'charset="utf-8"' in out or b"charset=utf-8" in out
+
+
+def test_output_rewrites_meta_when_prose_mentions_utf8():
+    """Space-separated 'encoding utf-8' in prose must not steal the declaration."""
+    payload = (
+        b"Note: encoding utf-8 is unsupported here.\n"
+        b'<meta charset="windows-1252">\n'
+        b"Cafe price: caf\xe9\n"
+    )
+    assert any_specified_encoding(payload) == "cp1252"
+    m = from_bytes(payload).best()
+    assert m is not None
+    out = m.output()
+    assert b'charset="utf-8"' in out or b"charset=utf-8" in out
+    assert b"windows-1252" not in out


### PR DESCRIPTION
The charset/encoding regex treated a bare space as a separator, so prose like "encoding of" was rewritten to "encoding utf-8" during output()/--normalize, and the real meta charset was left unchanged.

Require : or = as the separator, and only rewrite captures that match the preemptive declaration.