### PR TITLE
fix: write --normalize output beside the path given

### DIFF
--- a/src/charset_normalizer/cli/__main__.py
+++ b/src/charset_normalizer/cli/__main__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import sys
 import typing
-from os.path import abspath, basename, dirname, join, realpath
+from os.path import abspath, basename, dirname, join
 from platform import python_version
 from unicodedata import unidata_version
 
@@ -297,8 +297,8 @@ def cli_detect(argv: list[str] | None = None) -> int:
                         my_file.close()
                     continue
 
-                dir_path = dirname(realpath(my_file.name))
-                file_name = basename(realpath(my_file.name))
+                dir_path = dirname(abspath(my_file.name))
+                file_name = basename(my_file.name)
 
                 o_: list[str] = file_name.split(".")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -184,6 +184,33 @@ class TestCommandLineInterface(unittest.TestCase):
             cli_detect([DIR_PATH + "/data/sample-arabic-1.txt", "--force"]), 1
         )
 
+    def test_normalize_symlink_writes_beside_user_path(self):
+        """--normalize on a symlink must write beside the path given, using its basename."""
+        import os
+        import tempfile
+        from shutil import copyfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            real_dir = path.join(tmp, "real")
+            link_dir = path.join(tmp, "links")
+            os.mkdir(real_dir)
+            os.mkdir(link_dir)
+            real_file = path.join(real_dir, "report.txt")
+            copyfile(DIR_PATH + "/data/sample-arabic-1.txt", real_file)
+            link_file = path.join(link_dir, "alias.txt")
+            os.symlink(real_file, link_file)
+
+            self.assertEqual(0, cli_detect([link_file, "--normalize"]))
+
+            expected = path.join(link_dir, "alias.cp1256.txt")
+            unexpected = path.join(real_dir, "report.cp1256.txt")
+            self.assertTrue(path.exists(expected), expected)
+            self.assertFalse(path.exists(unexpected), unexpected)
+            try:
+                remove(expected)
+            except OSError:
+                pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
--normalize used realpath(), so a symlink alias.txt -> real/report.txt wrote report.<enc>.txt beside the target instead of alias.<enc>.txt beside the path passed on the command line.

Use abspath for the directory and the basename of the path given.